### PR TITLE
Add Content-Security-Policy-Report-Only header

### DIFF
--- a/src/Header/ContentSecurityPolicyReportOnly.php
+++ b/src/Header/ContentSecurityPolicyReportOnly.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-http for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Http\Header;
+
+/**
+ * Content Security Policy Level 3 Header
+ *
+ * @link http://www.w3.org/TR/CSP/
+ */
+class ContentSecurityPolicyReportOnly extends ContentSecurityPolicy
+{
+    /**
+     * Get the header name
+     *
+     * @return string
+     */
+    public function getFieldName()
+    {
+        return 'Content-Security-Policy-Report-Only';
+    }
+}

--- a/test/Header/ContentSecurityPolicyReportOnlyTest.php
+++ b/test/Header/ContentSecurityPolicyReportOnlyTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-http for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Http\Header;
+
+use Laminas\Http\Header\ContentSecurityPolicyReportOnly;
+use PHPUnit\Framework\TestCase;
+
+class ContentSecurityPolicyReportOnlyTest extends TestCase
+{
+    public function testContentSecurityPolicyReportOnlyToString()
+    {
+        $csp = ContentSecurityPolicyReportOnly::fromString(
+            "Content-Security-Policy-Report-Only: default-src 'none'; img-src 'self' https://*.gravatar.com;"
+        );
+        $this->assertEquals(
+            "Content-Security-Policy-Report-Only: default-src 'none'; img-src 'self' https://*.gravatar.com;",
+            $csp->toString()
+        );
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description
Content-Security-Policy-Report-Only header could be useful when experimenting with policies without impact of you application.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
