### PR TITLE
Fixes type-o in docblock that upsets phpstan/psalm

### DIFF
--- a/src/Header/AbstractAccept.php
+++ b/src/Header/AbstractAccept.php
@@ -293,7 +293,7 @@ abstract class AbstractAccept implements HeaderInterface
      * Match a media string against this header
      *
      * @param array|string $matchAgainst
-     * @return Accept\FieldValuePArt\AcceptFieldValuePart|bool The matched value or false
+     * @return Accept\FieldValuePart\AcceptFieldValuePart|bool The matched value or false
      */
     public function match($matchAgainst)
     {


### PR DESCRIPTION
Fixes #29

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixing case on class name in docblock for static analysis.