### PR TITLE
Fix namespace in return value of `AbstractAccept`

### DIFF
--- a/src/Header/AbstractAccept.php
+++ b/src/Header/AbstractAccept.php
@@ -293,7 +293,7 @@ abstract class AbstractAccept implements HeaderInterface
      * Match a media string against this header
      *
      * @param array|string $matchAgainst
-     * @return Accept\FieldValuePArt\AcceptFieldValuePart|bool The matched value or false
+     * @return Accept\FieldValuePart\AcceptFieldValuePart|bool The matched value or false
      */
     public function match($matchAgainst)
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | no

### Description

The return value of `AbstractAccept` contains a typo which results in some issues with static code analysis tools, e.g.