### PR TITLE
Normalize default user-agent string

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -110,7 +110,7 @@ class Client implements DispatchableInterface
     protected $config = [
         'maxredirects'    => 5,
         'strictredirects' => false,
-        'useragent'       => Client::class,
+        'useragent'       => 'Laminas_Http_Client',
         'timeout'         => 10,
         'connecttimeout'  => null,
         'adapter'         => Socket::class,

--- a/test/Client/CommonHttpTests.php
+++ b/test/Client/CommonHttpTests.php
@@ -150,7 +150,7 @@ abstract class CommonHttpTests extends TestCase
         $this->client->setUri($this->baseuri . 'testHeaders.php');
         $this->client->setParameterGet(['someinput' => 'somevalue']);
         $this->client->setHeaders([
-            'X-Powered-By' => 'My Glorious Golden Ass',
+            'X-Powered-By' => 'A lot of PHP',
         ]);
 
         $this->client->setMethod('TRACE');

--- a/test/Client/ProxyAdapterTest.php
+++ b/test/Client/ProxyAdapterTest.php
@@ -136,7 +136,7 @@ class ProxyAdapterTest extends SocketTest
         $this->client->setUri($this->baseuri . 'testHeaders.php');
         $this->client->setParameterGet(['someinput' => 'somevalue']);
         $this->client->setHeaders([
-            'X-Powered-By' => 'My Glorious Golden Ass',
+            'X-Powered-By' => 'A lot of PHP',
         ]);
 
         $this->client->setMethod('TRACE');
@@ -153,8 +153,8 @@ class ProxyAdapterTest extends SocketTest
             . 'Host: ' . $host . "\r\n"
             . 'Connection: close' . "\r\n"
             . 'Accept-Encoding: gzip, deflate' . "\r\n"
-            . 'User-Agent: Laminas\Http\Client' . "\r\n"
-            . 'X-Powered-By: My Glorious Golden Ass' . "\r\n\r\n",
+            . 'User-Agent: Laminas_Http_Client' . "\r\n"
+            . 'X-Powered-By: A lot of PHP' . "\r\n\r\n",
             $this->client->getLastRawRequest()
         );
 
@@ -162,8 +162,8 @@ class ProxyAdapterTest extends SocketTest
             'TRACE /testHeaders.php?someinput=somevalue HTTP/1.1' . "\r\n"
             . 'Host: ' . $host . "\r\n"
             . 'Accept-Encoding: gzip, deflate' . "\r\n"
-            . 'User-Agent: Laminas\Http\Client' . "\r\n"
-            . 'X-Powered-By: My Glorious Golden Ass' . "\r\n"
+            . 'User-Agent: Laminas_Http_Client' . "\r\n"
+            . 'X-Powered-By: A lot of PHP' . "\r\n"
             . 'Connection: close' . "\r\n\r\n",
             $res->getBody()
         );

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -26,6 +26,7 @@ use Laminas\Uri\Http;
 use LaminasTest\Http\TestAsset\ExtendedClient;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
+use ReflectionProperty;
 
 class ClientTest extends TestCase
 {
@@ -637,5 +638,16 @@ class ClientTest extends TestCase
         $response = $client->getResponse();
 
         self::assertSame($response->getBody(), file_get_contents($tmpFile));
+    }
+
+    public function testDefaultUserAgentDoesNotUseEscapeCharacter()
+    {
+        $client = new Client();
+        $r      = new ReflectionProperty($client, 'config');
+        $r->setAccessible(true);
+        $config = $r->getValue($client);
+        $this->assertInternalType('array', $config);
+        $this->assertArrayHasKey('useragent', $config);
+        $this->assertSame('Laminas_Http_Client', $config['useragent']);
     }
 }


### PR DESCRIPTION
Changes the default user-agent from `Laminas\Http\Client` to `Laminas_Http_Client`, as many servers and clients do not accept escape characters in the user-agent.

Fixes #38