### PR TITLE
Fixes #5 : Handle Response::sendHeaders() to not silently returns when header already sent

### DIFF
--- a/docs/book/response.md
+++ b/docs/book/response.md
@@ -141,7 +141,7 @@ EOS);
 
 ### handle Headers already sent
 
-Since 2.13.0, we can handle header already sent by pass callable via `Response::setHeadersSentHandler()`:
+> Available since version 2.13.0, we can handle header already sent by pass callable via `Response::setHeadersSentHandler()`:
 
 ```php
 use Laminas\Http\Response;

--- a/docs/book/response.md
+++ b/docs/book/response.md
@@ -138,3 +138,16 @@ $response->setContent(<<<EOS
 </html>
 EOS);
 ```
+
+### handle Headers already sent
+
+Since 2.13.0, we can handle header already sent by pass callable via `Response::setHeadersSentHandler()`:
+
+```php
+use Laminas\Http\Response;
+
+$response = new Response();
+$response->setHeadersSentHandler(function ($response): void {
+    throw new RuntimeException('Cannot send headers, headers already sent');
+});
+```

--- a/docs/book/response.md
+++ b/docs/book/response.md
@@ -141,7 +141,9 @@ EOS);
 
 ### handle Headers already sent
 
-> Available since version 2.13.0, we can handle header already sent by pass callable via `Response::setHeadersSentHandler()`:
+> Available since version 2.13.0
+
+We can handle header already sent by pass callable via `Response::setHeadersSentHandler()`:
 
 ```php
 use Laminas\Http\Response;

--- a/src/PhpEnvironment/Response.php
+++ b/src/PhpEnvironment/Response.php
@@ -106,7 +106,7 @@ class Response extends HttpResponse
     {
         if ($this->headersSent()) {
             if ($this->headersSentHandler) {
-                ($this->headersSentHandler)($this);
+                call_user_func($this->headersSentHandler, $this);
             }
 
             return $this;

--- a/src/PhpEnvironment/Response.php
+++ b/src/PhpEnvironment/Response.php
@@ -31,7 +31,7 @@ class Response extends HttpResponse
     protected $contentSent = false;
 
     /**
-     * @var bool
+     * @var callable
      */
     private $headersSentHandler;
 

--- a/src/PhpEnvironment/Response.php
+++ b/src/PhpEnvironment/Response.php
@@ -8,6 +8,7 @@
 
 namespace Laminas\Http\PhpEnvironment;
 
+use Laminas\Http\Exception\RuntimeException;
 use Laminas\Http\Header\MultipleHeaderInterface;
 use Laminas\Http\Response as HttpResponse;
 
@@ -82,7 +83,7 @@ class Response extends HttpResponse
     public function sendHeaders()
     {
         if ($this->headersSent()) {
-            return $this;
+            throw new RuntimeException('Cannot send headers, headers already sent');
         }
 
         $status  = $this->renderStatusLine();

--- a/src/PhpEnvironment/Response.php
+++ b/src/PhpEnvironment/Response.php
@@ -31,7 +31,7 @@ class Response extends HttpResponse
     protected $contentSent = false;
 
     /**
-     * @var callable
+     * @var null|callable
      */
     private $headersSentHandler;
 
@@ -81,19 +81,10 @@ class Response extends HttpResponse
     }
 
     /**
-     * @param callable $handler
+     * @return void
      */
-    public function setHeadersSentHandler($handler)
+    public function setHeadersSentHandler(callable $handler)
     {
-        if (! is_callable($handler)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Handler must be callable with passed response object in invokable parameter, received %s',
-                    gettype($handler)
-                )
-            );
-        }
-
         $this->headersSentHandler = $handler;
     }
 

--- a/test/PhpEnvironment/ResponseTest.php
+++ b/test/PhpEnvironment/ResponseTest.php
@@ -111,27 +111,16 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(Response::class, $response->sendHeaders());
     }
 
-    public function testSendHeadersHeadersAlreadySentPassInvalidHandler()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Handler must be callable with passed response object in invokable parameter, received string'
-        );
-
-        $response = new Response();
-        $response->setHeadersSentHandler('foo');
-        $response->sendHeaders();
-    }
-
     public function testSendHeadersHeadersAlreadySentPassValidHandler()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot send headers, headers already sent');
-
         $response = new Response();
         $response->setHeadersSentHandler(function ($response) {
             throw new RuntimeException('Cannot send headers, headers already sent');
         });
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot send headers, headers already sent');
+
         $response->sendHeaders();
     }
 }

--- a/test/PhpEnvironment/ResponseTest.php
+++ b/test/PhpEnvironment/ResponseTest.php
@@ -111,9 +111,6 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(Response::class, $response->sendHeaders());
     }
 
-    /**
-     * @runInSeparateProcesses
-     */
     public function testSendHeadersHeadersAlreadySentPassInvalidHandler()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -126,9 +123,6 @@ class ResponseTest extends TestCase
         $response->sendHeaders();
     }
 
-    /**
-     * @runInSeparateProcesses
-     */
     public function testSendHeadersHeadersAlreadySentPassValidHandler()
     {
         $this->expectException(RuntimeException::class);

--- a/test/PhpEnvironment/ResponseTest.php
+++ b/test/PhpEnvironment/ResponseTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Http\PhpEnvironment;
 
 use Laminas\Http\Exception\InvalidArgumentException;
+use Laminas\Http\Exception\RuntimeException;
 use Laminas\Http\PhpEnvironment\Response;
 use PHPUnit\Framework\TestCase;
 
@@ -99,5 +100,28 @@ class ResponseTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $response->setVersion('laminas/2.0');
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSendHeadersHeadersNotAlreadySent()
+    {
+        $response = new Response();
+        $this->assertInstanceOf(Response::class, $response->sendHeaders());
+    }
+
+    /**
+     * @runInSeparateProcesses
+     */
+    public function testSendHeadersHeadersAlreadySent()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot send headers, headers already sent');
+
+        echo 'test';
+
+        $response = new Response();
+        $response->sendHeaders();
     }
 }

--- a/test/PhpEnvironment/ResponseTest.php
+++ b/test/PhpEnvironment/ResponseTest.php
@@ -114,14 +114,30 @@ class ResponseTest extends TestCase
     /**
      * @runInSeparateProcesses
      */
-    public function testSendHeadersHeadersAlreadySent()
+    public function testSendHeadersHeadersAlreadySentPassInvalidHandler()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Handler must be callable with passed response object in invokable parameter, received string'
+        );
+
+        $response = new Response();
+        $response->setHeadersSentHandler('foo');
+        $response->sendHeaders();
+    }
+
+    /**
+     * @runInSeparateProcesses
+     */
+    public function testSendHeadersHeadersAlreadySentPassValidHandler()
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot send headers, headers already sent');
 
-        echo 'test';
-
         $response = new Response();
+        $response->setHeadersSentHandler(function ($response) {
+            throw new RuntimeException('Cannot send headers, headers already sent');
+        });
         $response->sendHeaders();
     }
 }


### PR DESCRIPTION
Signed-off-by: Abdul Malik Ikhsan <samsonasik@gmail.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| BC Break      | yes

### Description

Fixes https://github.com/laminas/laminas-http/issues/5 Handle Response::sendHeaders() to not silently returns when header already sent

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
