### PR TITLE
fix Curl error "transfer closed with ... bytes remaining to read" with HEAD HTTP method

### DIFF
--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -387,6 +387,9 @@ class Curl implements HttpAdapter, StreamInterface
         curl_setopt($this->curl, CURLOPT_HTTP_VERSION, $curlHttp);
         curl_setopt($this->curl, $curlMethod, $curlValue);
 
+        // Set the CURLOPT_NOBODY flag for HEAD HTTP method
+        curl_setopt($this->curl,CURLOPT_NOBODY,$curlMethod === CURLOPT_CUSTOMREQUEST && $curlValue === 'HEAD');
+
         // Set the CURLINFO_HEADER_OUT flag so that we can retrieve the full request string later
         curl_setopt($this->curl, CURLINFO_HEADER_OUT, true);
 

--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -388,7 +388,7 @@ class Curl implements HttpAdapter, StreamInterface
         curl_setopt($this->curl, $curlMethod, $curlValue);
 
         // Set the CURLOPT_NOBODY flag for HEAD HTTP method
-        curl_setopt($this->curl,CURLOPT_NOBODY,$curlMethod === CURLOPT_CUSTOMREQUEST && $curlValue === 'HEAD');
+        curl_setopt($this->curl, CURLOPT_NOBODY, $curlMethod === CURLOPT_CUSTOMREQUEST && $curlValue === 'HEAD');
 
         // Set the CURLINFO_HEADER_OUT flag so that we can retrieve the full request string later
         curl_setopt($this->curl, CURLINFO_HEADER_OUT, true);

--- a/test/Client/CurlTest.php
+++ b/test/Client/CurlTest.php
@@ -365,7 +365,7 @@ class CurlTest extends CommonHttpTests
      */
     public function testHeadRequest()
     {
-        $this->client->setUri($this->baseuri . 'testRawPostData.php');
+        $this->client->setUri($this->baseuri . 'testHeadMethod.php');
         $adapter = new Adapter\Curl();
         $this->client->setAdapter($adapter);
         $this->client->setMethod('HEAD');

--- a/test/Client/CurlTest.php
+++ b/test/Client/CurlTest.php
@@ -365,6 +365,16 @@ class CurlTest extends CommonHttpTests
      */
     public function testHeadRequest()
     {
+        $this->client->setUri($this->baseuri . 'testRawPostData.php');
+        $adapter = new Adapter\Curl();
+        $this->client->setAdapter($adapter);
+        $this->client->setMethod('HEAD');
+        $this->client->send();
+        $this->assertEquals('', $this->client->getResponse()->getBody());
+    }
+
+    public function testHeadRequestWithContentLengthHeader()
+    {
         $this->client->setUri($this->baseuri . 'testHeadMethod.php');
         $adapter = new Adapter\Curl();
         $this->client->setAdapter($adapter);

--- a/test/Client/_files/testHeadMethod.php
+++ b/test/Client/_files/testHeadMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-http for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
+ */
+
+
+$clength = filesize(__FILE__);
+
+header(sprintf('Content-length: %s', $clength));


### PR DESCRIPTION


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

> The HTTP HEAD method requests the headers that would be returned if the HEAD request's URL was instead requested with the HTTP GET method. For example, if a URL might produce a large download, a HEAD request could read its Content-Length header to check the filesize without actually downloading the file.

[https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD)