### PR TITLE
Allow to use DateTimeInterface in the SetCookie::setExpires

### DIFF
--- a/docs/book/headers.md
+++ b/docs/book/headers.md
@@ -442,7 +442,7 @@ Method signature                                                      | Descript
 `getValue() : string`                                                 | Retrieve the cookie value.
 `setValue(string $value) : self`                                      | Set the cookie value.
 `getExpires() : int`                                                  | Retrieve the expiration date for the cookie.
-`setExpires(int|string $expires) : self`                              | Set the cookie expiration timestamp; null indicates a session cookie.
+`setExpires(int|string|DateTimeInterface $expires) : self`                              | Set the cookie expiration timestamp; null indicates a session cookie.
 `getPath() : string`                                                  | Retrieve the URI path the cookie is bound to.
 `setPath(string $path) : self`                                        | Set the URI path the cookie is bound to.
 `getDomain() : string`                                                | Retrieve the domain the cookie is bound to.

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -9,6 +9,7 @@
 namespace Laminas\Http\Header;
 
 use DateTime;
+use DateTimeInterface;
 use Laminas\Uri\UriFactory;
 
 use function array_key_exists;
@@ -231,16 +232,16 @@ class SetCookie implements MultipleHeaderInterface
      *
      * @todo Add validation of each one of the parameters (legal domain, etc.)
      *
-     * @param string|null              $name
-     * @param string|null              $value
-     * @param int|string|DateTime|null $expires
-     * @param string|null              $path
-     * @param string|null              $domain
-     * @param bool                     $secure
-     * @param bool                     $httponly
-     * @param int|null                 $maxAge
-     * @param int|null                 $version
-     * @param string|null              $sameSite
+     * @param string|null                       $name
+     * @param string|null                       $value
+     * @param int|string|DateTimeInterface|null $expires
+     * @param string|null                       $path
+     * @param string|null                       $domain
+     * @param bool                              $secure
+     * @param bool                              $httponly
+     * @param int|null                          $maxAge
+     * @param int|null                          $version
+     * @param string|null                       $sameSite
      */
     public function __construct(
         $name = null,
@@ -433,7 +434,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  int|string|DateTime|null $expires
+     * @param  int|string|DateTimeInterface|null $expires
      * @return $this
      * @throws Exception\InvalidArgumentException
      */
@@ -444,8 +445,8 @@ class SetCookie implements MultipleHeaderInterface
             return $this;
         }
 
-        if ($expires instanceof DateTime) {
-            $expires = $expires->format(DateTime::COOKIE);
+        if ($expires instanceof DateTimeInterface) {
+            $expires = $expires->format(DateTimeInterface::COOKIE);
         }
 
         $tsExpires = $expires;

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Http\Header;
 
 use DateTime;
+use DateTimeImmutable;
 use Laminas\Http\Header\Exception\InvalidArgumentException;
 use Laminas\Http\Header\HeaderInterface;
 use Laminas\Http\Header\MultipleHeaderInterface;
@@ -309,6 +310,24 @@ class SetCookieTest extends TestCase
         $setCookieHeader->setName('myname');
         $setCookieHeader->setValue('myvalue');
         $setCookieHeader->setExpires(new DateTime('Wed, 13-Jan-2021 22:23:01 GMT'));
+        $setCookieHeader->setDomain('docs.foo.com');
+        $setCookieHeader->setPath('/accounts');
+        $setCookieHeader->setSecure(true);
+        $setCookieHeader->setHttponly(true);
+
+        $target = 'myname=myvalue; Expires=Wed, 13-Jan-2021 22:23:01 GMT;'
+            . ' Domain=docs.foo.com; Path=/accounts;'
+            . ' Secure; HttpOnly';
+
+        $this->assertEquals($target, $setCookieHeader->getFieldValue());
+    }
+
+    public function testSetCookieWithInstanceOfDateTimeInterfaceFieldValueReturnsProperValue()
+    {
+        $setCookieHeader = new SetCookie();
+        $setCookieHeader->setName('myname');
+        $setCookieHeader->setValue('myvalue');
+        $setCookieHeader->setExpires(new DateTimeImmutable('Wed, 13-Jan-2021 22:23:01 GMT'));
         $setCookieHeader->setDomain('docs.foo.com');
         $setCookieHeader->setPath('/accounts');
         $setCookieHeader->setSecure(true);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

Allow to use instance of DateTimeInterface in the SetCookie::setExpires