### PR TITLE
Provide PHP 8.1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
+/.phpcs-cache
+/.phpunit.result.cache
 /clover.xml
-/composer.lock
 /coveralls-upload.json
 /docs/html/
 /laminas-mkdoc-theme.tgz
 /laminas-mkdoc-theme/
 /phpunit.xml
 /vendor/
-/.phpunit.result.cache

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,5 @@
+{
+    "ignore_php_platform_requirements": {
+        "8.1": true
+    }
+}

--- a/.laminas-ci/pre-run.sh
+++ b/.laminas-ci/pre-run.sh
@@ -19,17 +19,19 @@ cp .laminas-ci/phpunit.xml phpunit.xml
 
 # Install dependendies
 apt update -qq
-apt install -y apache2 php${PHP_VERSION}-fpm
+# Hack because apache2 package attempts to write to 000-default.conf twice
+apt-get install -o Dpkg::Options::="--force-confnew" -y apache2
+apt install -y "php${PHP_VERSION}-fpm"
 
 # Enable required modules
 a2enmod rewrite actions proxy_fcgi setenvif alias
-a2enconf php${PHP_VERSION}-fpm
+a2enconf "php${PHP_VERSION}-fpm"
 
 # Setup and start php-fpm
-echo "cgi.fix_pathinfo = 1" >> /etc/php/${PHP_VERSION}/fpm/php.ini
-sed -i -e "s,www-data,${TEST_USER},g" /etc/php/${PHP_VERSION}/fpm/pool.d/www.conf
+echo "cgi.fix_pathinfo = 1" >> "/etc/php/${PHP_VERSION}/fpm/php.ini"
+sed -i -e "s,www-data,${TEST_USER},g" "/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf"
 sed -i -e "s,www-data,${TEST_USER},g" /etc/apache2/envvars
-service php${PHP_VERSION}-fpm start
+service "php${PHP_VERSION}-fpm" start
 
 # configure apache virtual hosts
 echo "ServerName 127.0.0.1" >> /etc/apache2/apache2.conf

--- a/.laminas-ci/pre-run.sh
+++ b/.laminas-ci/pre-run.sh
@@ -21,7 +21,11 @@ cp .laminas-ci/phpunit.xml phpunit.xml
 apt update -qq
 # Hack because apache2 package attempts to write to 000-default.conf twice
 apt-get install -o Dpkg::Options::="--force-confnew" -y apache2
-apt install -y "php${PHP_VERSION}-fpm"
+if [[ "${PHP_VERSION}" == "8.1" ]];then
+    switch_sapi -v 8.1 -s fpm:apache
+else
+    apt install -y "php${PHP_VERSION}-fpm"
+fi
 
 # Enable required modules
 a2enmod rewrite actions proxy_fcgi setenvif alias

--- a/.laminas-ci/pre-run.sh
+++ b/.laminas-ci/pre-run.sh
@@ -22,7 +22,9 @@ apt update -qq
 # Hack because apache2 package attempts to write to 000-default.conf twice
 apt-get install -o Dpkg::Options::="--force-confnew" -y apache2
 if [[ "${PHP_VERSION}" == "8.1" ]];then
-    switch_sapi -v 8.1 -s fpm:apache
+    # This might not be necessary
+    # switch_sapi -v 8.1 -s fpm:apache
+    echo "Skipping FPM installation on PHP 8.1"
 else
     apt install -y "php${PHP_VERSION}-fpm"
 fi

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,15 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
-        "laminas/laminas-loader": "^2.5.1",
-        "laminas/laminas-stdlib": "^3.2.1",
-        "laminas/laminas-uri": "^2.5.2",
-        "laminas/laminas-validator": "^2.10.1",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "laminas/laminas-loader": "^2.8",
+        "laminas/laminas-stdlib": "^3.6",
+        "laminas/laminas-uri": "^2.9",
+        "laminas/laminas-validator": "^2.15"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
-        "laminas/laminas-config": "^3.1 || ^2.6",
-        "phpunit/phpunit": "^9.3"
+        "laminas/laminas-coding-standard": "~2.2.1",
+        "phpunit/phpunit": "^9.5.5"
     },
     "suggest": {
         "paragonie/certainty": "For automated management of cacert.pem"
@@ -55,7 +53,7 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zendframework/zend-http": "^2.11.2"
+    "conflict": {
+        "zendframework/zend-http": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-loader": "^2.8",
         "laminas/laminas-stdlib": "^3.6",
-        "laminas/laminas-uri": "^2.9",
+        "laminas/laminas-uri": "^2.9.1",
         "laminas/laminas-validator": "^2.15"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2871 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "6156759afffef21f7325de36a76338df",
+    "packages": [
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "support": {
+                "issues": "https://github.com/container-interop/container-interop/issues",
+                "source": "https://github.com/container-interop/container-interop/tree/master"
+            },
+            "abandoned": "psr/container",
+            "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
+            "name": "laminas/laminas-escaper",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-escaper.git",
+                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/891ad70986729e20ed2e86355fcf93c9dc238a5f",
+                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "conflict": {
+                "zendframework/zend-escaper": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "phpunit/phpunit": "^9.3",
+                "psalm/plugin-phpunit": "^0.12.2",
+                "vimeo/psalm": "^3.16"
+            },
+            "suggest": {
+                "ext-iconv": "*",
+                "ext-mbstring": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "escaper",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-escaper/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-escaper/issues",
+                "rss": "https://github.com/laminas/laminas-escaper/releases.atom",
+                "source": "https://github.com/laminas/laminas-escaper"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-02T17:10:53+00:00"
+        },
+        {
+            "name": "laminas/laminas-loader",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-loader.git",
+                "reference": "d0589ec9dd48365fd95ad10d1c906efd7711c16b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/d0589ec9dd48365fd95ad10d1c906efd7711c16b",
+                "reference": "d0589ec9dd48365fd95ad10d1c906efd7711c16b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "conflict": {
+                "zendframework/zend-loader": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Loader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Autoloading and plugin loading strategies",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "loader"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-loader/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-loader/issues",
+                "rss": "https://github.com/laminas/laminas-loader/releases.atom",
+                "source": "https://github.com/laminas/laminas-loader"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-02T18:30:53+00:00"
+        },
+        {
+            "name": "laminas/laminas-stdlib",
+            "version": "3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stdlib.git",
+                "reference": "c53d8537f108fac3fae652677a19735db730ba46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/c53d8537f108fac3fae652677a19735db730ba46",
+                "reference": "c53d8537f108fac3fae652677a19735db730ba46",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "conflict": {
+                "zendframework/zend-stdlib": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "phpbench/phpbench": "^0.17.1",
+                "phpunit/phpunit": "~9.3.7",
+                "psalm/plugin-phpunit": "^0.16.0",
+                "vimeo/psalm": "^4.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "stdlib"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-stdlib/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-stdlib/issues",
+                "rss": "https://github.com/laminas/laminas-stdlib/releases.atom",
+                "source": "https://github.com/laminas/laminas-stdlib"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-02T16:11:32+00:00"
+        },
+        {
+            "name": "laminas/laminas-uri",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-uri.git",
+                "reference": "34c9386b7058bd52b3ea3b150bb34e0c97812c55"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/34c9386b7058bd52b3ea3b150bb34e0c97812c55",
+                "reference": "34c9386b7058bd52b3ea3b150bb34e0c97812c55",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-escaper": "^2.9",
+                "laminas/laminas-validator": "^2.15",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "conflict": {
+                "zendframework/zend-uri": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "phpunit/phpunit": "^9.5.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "uri"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-uri/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-uri/issues",
+                "rss": "https://github.com/laminas/laminas-uri/releases.atom",
+                "source": "https://github.com/laminas/laminas-uri"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-09T13:57:23+00:00"
+        },
+        {
+            "name": "laminas/laminas-validator",
+            "version": "2.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-validator.git",
+                "reference": "270380e87904f5a1a1fba3059989d4ca157e16a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/270380e87904f5a1a1fba3059989d4ca157e16a9",
+                "reference": "270380e87904f5a1a1fba3059989d4ca157e16a9",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-stdlib": "^3.6",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "conflict": {
+                "zendframework/zend-validator": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-cache": "^2.6.1",
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "laminas/laminas-db": "^2.7",
+                "laminas/laminas-filter": "^2.6",
+                "laminas/laminas-http": "^2.14.2",
+                "laminas/laminas-i18n": "^2.6",
+                "laminas/laminas-math": "^2.6",
+                "laminas/laminas-servicemanager": "^2.7.11 || ^3.0.3",
+                "laminas/laminas-session": "^2.8",
+                "laminas/laminas-uri": "^2.7",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.15.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "vimeo/psalm": "^4.3"
+            },
+            "suggest": {
+                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
+                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
+                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
+                "laminas/laminas-i18n-resources": "Translations of validator messages",
+                "laminas/laminas-math": "Laminas\\Math component, required by the Csrf validator",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
+                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
+                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Validator",
+                    "config-provider": "Laminas\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "validator"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-validator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-validator/issues",
+                "rss": "https://github.com/laminas/laminas-validator/releases.atom",
+                "source": "https://github.com/laminas/laminas-validator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-08T23:16:56+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
+            },
+            "time": "2021-03-05T17:36:06+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "laminas/laminas-coding-standard",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-coding-standard.git",
+                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/c953ecb1d37034f4aa326046e2c24a10fe0a2845",
+                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.3 || ~8.0.0",
+                "slevomat/coding-standard": "^6.4.1",
+                "squizlabs/php_codesniffer": "^3.5.8",
+                "webimpress/coding-standard": "^1.1.6"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas Coding Standard",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "Coding Standard",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-coding-standard/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-coding-standard/issues",
+                "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
+                "source": "https://github.com/laminas/laminas-coding-standard"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-05-17T17:39:41+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
+            },
+            "time": "2021-07-21T10:44:31+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
+            },
+            "time": "2021-02-23T14:00:09+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+            },
+            "time": "2020-09-03T19:13:55+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+            },
+            "time": "2020-09-17T18:55:26+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2",
+                "php": "^7.2 || ~8.0, <8.1",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^6.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
+            },
+            "time": "2021-03-17T13:42:18+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "symfony/process": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f6293e1b30a2354e8428e004689671b83871edde",
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.10.2",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-28T07:26:59+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:57:25+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.5.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.3.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpspec/prophecy": "^1.12.1",
+                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.5",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.3",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^2.3.4",
+                "sebastian/version": "^3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*",
+                "phpspec/prophecy-phpunit": "^2.0.1"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.9"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-08-31T06:47:40+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:49:45+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:10:38+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:52:38+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:24:23+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-06-11T13:31:12+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:17:30+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2020-09-28T06:45:17+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "2.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-06-15T12:49:02+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "6.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "phing/phing": "2.16.3",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-05T12:39:37+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-04-09T00:54:41+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-28T10:34:58+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-12T12:51:27+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+            },
+            "time": "2021-03-09T10:59:23+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^7.3 || ~8.0.0 || ~8.1.0"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6156759afffef21f7325de36a76338df",
+    "content-hash": "3bfcee73d78e113600374665bbe4e8a0",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -221,16 +221,16 @@
         },
         {
             "name": "laminas/laminas-uri",
-            "version": "2.9.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-uri.git",
-                "reference": "34c9386b7058bd52b3ea3b150bb34e0c97812c55"
+                "reference": "7e837dc15c8fd3949df7d1213246fd7c8640032b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/34c9386b7058bd52b3ea3b150bb34e0c97812c55",
-                "reference": "34c9386b7058bd52b3ea3b150bb34e0c97812c55",
+                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/7e837dc15c8fd3949df7d1213246fd7c8640032b",
+                "reference": "7e837dc15c8fd3949df7d1213246fd7c8640032b",
                 "shasum": ""
             },
             "require": {
@@ -275,7 +275,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-09T13:57:23+00:00"
+            "time": "2021-09-09T18:37:15+00:00"
         },
         {
             "name": "laminas/laminas-validator",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
-
-    <!-- Paths to check -->
-    <file>src</file>
-    <file>test</file>
-    <exclude-pattern>*/_files/*</exclude-pattern>
-</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0"?>
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
+
+    <!-- Paths to check -->
+    <file>src</file>
+    <file>test</file>
+    <exclude-pattern>*/_files/*</exclude-pattern>
+
+    <!-- Include all rules from Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
+</ruleset>

--- a/src/AbstractMessage.php
+++ b/src/AbstractMessage.php
@@ -1,14 +1,11 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http;
 
 use Laminas\Stdlib\Message;
+
+use function in_array;
+use function is_string;
 
 /**
  * HTTP standard message (Request/Response)
@@ -18,21 +15,18 @@ use Laminas\Stdlib\Message;
 abstract class AbstractMessage extends Message
 {
     /**#@+
+     *
      * @const string Version constant numbers
      */
-    const VERSION_10 = '1.0';
-    const VERSION_11 = '1.1';
-    const VERSION_2  = '2';
+    public const VERSION_10 = '1.0';
+    public const VERSION_11 = '1.1';
+    public const VERSION_2  = '2';
     /**#@-*/
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $version = self::VERSION_11;
 
-    /**
-     * @var Headers|null
-     */
+    /** @var Headers|null */
     protected $headers;
 
     /**
@@ -69,7 +63,7 @@ abstract class AbstractMessage extends Message
      * (this is NOT the primary API for value setting, for that see getHeaders())
      *
      * @see    getHeaders()
-     * @param  Headers $headers
+     *
      * @return $this
      */
     public function setHeaders(Headers $headers)
@@ -87,7 +81,7 @@ abstract class AbstractMessage extends Message
     {
         if ($this->headers === null || is_string($this->headers)) {
             // this is only here for fromString lazy loading
-            $this->headers = (is_string($this->headers)) ? Headers::fromString($this->headers) : new Headers();
+            $this->headers = is_string($this->headers) ? Headers::fromString($this->headers) : new Headers();
         }
 
         return $this->headers;

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,16 +1,11 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http;
 
 use ArrayIterator;
 use Laminas\Http\Client\Adapter\Curl;
 use Laminas\Http\Client\Adapter\Socket;
+use Laminas\Http\Client\Exception\RuntimeException;
 use Laminas\Http\Header\SetCookie;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\DispatchableInterface;
@@ -20,6 +15,54 @@ use Laminas\Stdlib\ResponseInterface;
 use Laminas\Uri\Http;
 use Traversable;
 
+use function array_merge;
+use function base64_encode;
+use function basename;
+use function class_exists;
+use function defined;
+use function explode;
+use function fclose;
+use function file_get_contents;
+use function finfo_file;
+use function finfo_open;
+use function fopen;
+use function fstat;
+use function func_get_arg;
+use function func_num_args;
+use function function_exists;
+use function http_build_query;
+use function in_array;
+use function ini_get;
+use function is_array;
+use function is_int;
+use function is_resource;
+use function is_string;
+use function md5;
+use function microtime;
+use function mime_content_type;
+use function preg_match;
+use function preg_quote;
+use function rewind;
+use function rtrim;
+use function sprintf;
+use function str_replace;
+use function stream_get_meta_data;
+use function stripos;
+use function strlen;
+use function strpos;
+use function strrpos;
+use function strtolower;
+use function strtoupper;
+use function substr;
+use function sys_get_temp_dir;
+use function tempnam;
+use function trim;
+
+use const CURLAUTH_DIGEST;
+use const CURLOPT_HTTPAUTH;
+use const CURLOPT_USERPWD;
+use const FILEINFO_MIME;
+
 /**
  * Http client
  */
@@ -28,78 +71,56 @@ class Client implements DispatchableInterface
     /**
      * @const string Supported HTTP Authentication methods
      */
-    const AUTH_BASIC  = 'basic';
-    const AUTH_DIGEST = 'digest';
+    public const AUTH_BASIC  = 'basic';
+    public const AUTH_DIGEST = 'digest';
 
     /**
      * @const string POST data encoding methods
      */
-    const ENC_URLENCODED = 'application/x-www-form-urlencoded';
-    const ENC_FORMDATA   = 'multipart/form-data';
+    public const ENC_URLENCODED = 'application/x-www-form-urlencoded';
+    public const ENC_FORMDATA   = 'multipart/form-data';
 
     /**
      * @const string DIGEST Authentication
      */
-    const DIGEST_REALM  = 'realm';
-    const DIGEST_QOP    = 'qop';
-    const DIGEST_NONCE  = 'nonce';
-    const DIGEST_OPAQUE = 'opaque';
-    const DIGEST_NC     = 'nc';
-    const DIGEST_CNONCE = 'cnonce';
+    public const DIGEST_REALM  = 'realm';
+    public const DIGEST_QOP    = 'qop';
+    public const DIGEST_NONCE  = 'nonce';
+    public const DIGEST_OPAQUE = 'opaque';
+    public const DIGEST_NC     = 'nc';
+    public const DIGEST_CNONCE = 'cnonce';
 
-    /**
-     * @var Response
-     */
+    /** @var Response */
     protected $response;
 
-    /**
-     * @var Request
-     */
+    /** @var Request */
     protected $request;
 
-    /**
-     * @var Client\Adapter\AdapterInterface
-     */
+    /** @var Client\Adapter\AdapterInterface */
     protected $adapter;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $auth = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $streamName;
 
-    /**
-     * @var resource|null
-     */
-    protected $streamHandle = null;
+    /** @var resource|null */
+    protected $streamHandle;
 
-    /**
-     * @var array of Header\SetCookie
-     */
+    /** @var array of Header\SetCookie */
     protected $cookies = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $encType = '';
 
-    /**
-     * @var Request
-     */
+    /** @var Request */
     protected $lastRawRequest;
 
-    /**
-     * @var Response
-     */
+    /** @var Response */
     protected $lastRawResponse;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $redirectCounter = 0;
 
     /**
@@ -198,7 +219,7 @@ class Client implements DispatchableInterface
                     'Unable to locate adapter class "' . $adapter . '"'
                 );
             }
-            $adapter = new $adapter;
+            $adapter = new $adapter();
         }
 
         if (! $adapter instanceof Client\Adapter\AdapterInterface) {
@@ -206,7 +227,7 @@ class Client implements DispatchableInterface
         }
 
         $this->adapter = $adapter;
-        $config = $this->config;
+        $config        = $this->config;
         unset($config['adapter']);
         $this->adapter->setOptions($config);
         return $this;
@@ -229,7 +250,6 @@ class Client implements DispatchableInterface
     /**
      * Set request
      *
-     * @param Request $request
      * @return $this
      */
     public function setRequest(Request $request)
@@ -255,7 +275,6 @@ class Client implements DispatchableInterface
     /**
      * Set response
      *
-     * @param Response $response
      * @return $this
      */
     public function setResponse(Response $response)
@@ -328,8 +347,8 @@ class Client implements DispatchableInterface
                 $this->clearAuth();
             }
 
-            $uri = $this->getUri();
-            $user = $uri->getUser();
+            $uri      = $this->getUri();
+            $user     = $uri->getUser();
             $password = $uri->getPassword();
 
             // Set auth if username and password has been specified in the uri
@@ -365,7 +384,8 @@ class Client implements DispatchableInterface
     {
         $method = $this->getRequest()->setMethod($method)->getMethod();
 
-        if (empty($this->encType)
+        if (
+            empty($this->encType)
             && in_array(
                 $method,
                 [
@@ -493,10 +513,9 @@ class Client implements DispatchableInterface
      * Reset all the HTTP parameters (request, response, etc)
      *
      * @param  bool   $clearCookies  Also clear all valid cookies? (defaults to false)
-     * @param  bool   $clearAuth     Also clear http authentication? (defaults to true)
      * @return $this
      */
-    public function resetParameters($clearCookies = false /*, $clearAuth = true */)
+    public function resetParameters($clearCookies = false)
     {
         $clearAuth = true;
         if (func_num_args() > 1) {
@@ -538,12 +557,12 @@ class Client implements DispatchableInterface
     /**
      * Get the cookie Id (name+domain+path)
      *
-     * @param  Header\SetCookie|Header\Cookie $cookie
+     * @param  SetCookie|Header\Cookie $cookie
      * @return string|bool
      */
     protected function getCookieId($cookie)
     {
-        if (($cookie instanceof Header\SetCookie) || ($cookie instanceof Header\Cookie)) {
+        if ($cookie instanceof Header\SetCookie || $cookie instanceof Header\Cookie) {
             return $cookie->getName() . $cookie->getDomain() . $cookie->getPath();
         }
         return false;
@@ -552,7 +571,7 @@ class Client implements DispatchableInterface
     /**
      * Add a cookie
      *
-     * @param array|ArrayIterator|Header\SetCookie|string $cookie
+     * @param array|ArrayIterator|SetCookie|string $cookie
      * @param string  $value
      * @param string  $expire
      * @param string  $path
@@ -584,7 +603,7 @@ class Client implements DispatchableInterface
                 }
             }
         } elseif (is_string($cookie) && $value !== null) {
-            $setCookie = new Header\SetCookie(
+            $setCookie                                     = new SetCookie(
                 $cookie,
                 $value,
                 $expire,
@@ -706,6 +725,7 @@ class Client implements DispatchableInterface
 
     /**
      * Get status of streaming for received data
+     *
      * @return bool|string
      */
     public function getStream()
@@ -730,8 +750,8 @@ class Client implements DispatchableInterface
         if (! is_string($this->streamName)) {
             // If name is not given, create temp name
             $this->streamName = tempnam(
-                isset($this->config['streamtmpdir']) ? $this->config['streamtmpdir'] : sys_get_temp_dir(),
-                Client::class
+                $this->config['streamtmpdir'] ?? sys_get_temp_dir(),
+                self::class
             );
         }
 
@@ -792,6 +812,7 @@ class Client implements DispatchableInterface
      * Calculate the response value according to the HTTP authentication type
      *
      * @see http://www.faqs.org/rfcs/rfc2617.html
+     *
      * @param string $user
      * @param string $password
      * @param string $type
@@ -832,9 +853,9 @@ class Client implements DispatchableInterface
                     }
                 }
                 $ha1 = md5($user . ':' . $digest['realm'] . ':' . $password);
-                if (empty($digest['qop']) || strtolower($digest['qop']) == 'auth') {
+                if (empty($digest['qop']) || strtolower($digest['qop']) === 'auth') {
                     $ha2 = md5($this->getMethod() . ':' . $this->getUri()->getPath());
-                } elseif (strtolower($digest['qop']) == 'auth-int') {
+                } elseif (strtolower($digest['qop']) === 'auth-int') {
                     if (empty($entityBody)) {
                         throw new Exception\InvalidArgumentException(
                             'I cannot use the auth-int digest authentication without the entity body'
@@ -856,11 +877,9 @@ class Client implements DispatchableInterface
     /**
      * Dispatch
      *
-     * @param RequestInterface $request
-     * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    public function dispatch(RequestInterface $request, ResponseInterface $response = null)
+    public function dispatch(RequestInterface $request, ?ResponseInterface $response = null)
     {
         return $this->send($request);
     }
@@ -868,12 +887,11 @@ class Client implements DispatchableInterface
     /**
      * Send HTTP request
      *
-     * @param  Request|null $request
      * @return Response
      * @throws Exception\RuntimeException
-     * @throws Client\Exception\RuntimeException
+     * @throws RuntimeException
      */
-    public function send(Request $request = null)
+    public function send(?Request $request = null)
     {
         if ($request !== null) {
             $this->setRequest($request);
@@ -895,7 +913,7 @@ class Client implements DispatchableInterface
                 $queryArray = $query->toArray();
 
                 if (! empty($queryArray)) {
-                    $newUri = $uri->toString();
+                    $newUri      = $uri->toString();
                     $queryString = http_build_query($queryArray, null, $this->getArgSeparator());
 
                     if ($this->config['rfc3986strict']) {
@@ -928,7 +946,7 @@ class Client implements DispatchableInterface
             // headers
             $headers = $this->prepareHeaders($body, $uri);
 
-            $secure = $uri->getScheme() == 'https';
+            $secure = $uri->getScheme() === 'https';
 
             // cookies
             $cookie = $this->prepareCookies($uri->getHost(), $uri->getPath(), $secure);
@@ -937,15 +955,15 @@ class Client implements DispatchableInterface
             }
 
             // check that adapter supports streaming before using it
-            if (is_resource($body) && ! ($adapter instanceof Client\Adapter\StreamInterface)) {
-                throw new Client\Exception\RuntimeException('Adapter does not support streaming');
+            if (is_resource($body) && ! $adapter instanceof Client\Adapter\StreamInterface) {
+                throw new RuntimeException('Adapter does not support streaming');
             }
 
             $this->streamHandle = null;
             // calling protected method to allow extending classes
             // to wrap the interaction with the adapter
-            $response = $this->doRequest($uri, $method, $secure, $headers, $body);
-            $stream = $this->streamHandle;
+            $response           = $this->doRequest($uri, $method, $secure, $headers, $body);
+            $stream             = $this->streamHandle;
             $this->streamHandle = null;
 
             if (! $response) {
@@ -998,24 +1016,26 @@ class Client implements DispatchableInterface
 
                 // Check whether we send the exact same request again, or drop the parameters
                 // and send a GET request
-                if ($response->getStatusCode() == 303
+                if (
+                    $response->getStatusCode() === 303
                     || ((! $this->config['strictredirects'])
-                        && ($response->getStatusCode() == 302 || $response->getStatusCode() == 301))
+                        && ($response->getStatusCode() === 302 || $response->getStatusCode() === 301))
                 ) {
                     $this->resetParameters(false, false);
                     $this->setMethod(Request::METHOD_GET);
                 }
 
                 // If we got a well formed absolute URI
-                if (($scheme = substr($location, 0, 6))
-                    && ($scheme == 'http:/' || $scheme == 'https:')
+                if (
+                    ($scheme = substr($location, 0, 6))
+                    && ($scheme === 'http:/' || $scheme === 'https:')
                 ) {
                     // setURI() clears parameters if host changed, see #4215
                     $this->setUri($location);
                 } else {
                     // Split into path and query and set the query
                     if (strpos($location, '?') !== false) {
-                        list($location, $query) = explode('?', $location, 2);
+                        [$location, $query] = explode('?', $location, 2);
                     } else {
                         $query = '';
                     }
@@ -1097,8 +1117,8 @@ class Client implements DispatchableInterface
         $this->getRequest()->getFiles()->set($filename, [
             'formname' => $formname,
             'filename' => basename($filename),
-            'ctype' => $ctype,
-            'data' => $data,
+            'ctype'    => $ctype,
+            'data'     => $data,
         ]);
 
         return $this;
@@ -1165,11 +1185,12 @@ class Client implements DispatchableInterface
         $headers = [];
 
         // Set the host header
-        if ($this->config['httpversion'] == Request::VERSION_11) {
+        if ($this->config['httpversion'] === Request::VERSION_11) {
             $host = $uri->getHost();
             // If the port is not default, add it
-            if (! (($uri->getScheme() == 'http' && $uri->getPort() == 80)
-                || ($uri->getScheme() == 'https' && $uri->getPort() == 443))
+            if (
+                ! (($uri->getScheme() === 'http' && $uri->getPort() === 80)
+                || ($uri->getScheme() === 'https' && $uri->getPort() === 443))
             ) {
                 $host .= ':' . $uri->getPort();
             }
@@ -1229,7 +1250,7 @@ class Client implements DispatchableInterface
 
         if (! empty($body)) {
             if (is_resource($body)) {
-                $fstat = fstat($body);
+                $fstat                     = fstat($body);
                 $headers['Content-Length'] = $fstat['size'];
             } else {
                 $headers['Content-Length'] = strlen($body);
@@ -1249,7 +1270,7 @@ class Client implements DispatchableInterface
      * Prepare the request body (for PATCH, POST and PUT requests)
      *
      * @return string
-     * @throws \Laminas\Http\Client\Exception\RuntimeException
+     * @throws RuntimeException
      */
     protected function prepareBody()
     {
@@ -1263,7 +1284,7 @@ class Client implements DispatchableInterface
             return $rawBody;
         }
 
-        $body = '';
+        $body     = '';
         $hasFiles = false;
 
         if (! $this->getRequest()->getHeaders()->has('Content-Type')) {
@@ -1304,7 +1325,7 @@ class Client implements DispatchableInterface
                 // Encode body as application/x-www-form-urlencoded
                 $body = http_build_query($this->getRequest()->getPost()->toArray(), null, '&');
             } else {
-                throw new Client\Exception\RuntimeException(sprintf(
+                throw new RuntimeException(sprintf(
                     'Cannot handle content type \'%s\' automatically',
                     $this->encType
                 ));
@@ -1313,7 +1334,6 @@ class Client implements DispatchableInterface
 
         return $body;
     }
-
 
     /**
      * Attempt to detect the MIME type of a file using available extensions
@@ -1394,7 +1414,6 @@ class Client implements DispatchableInterface
      * key to indicate an array.
      *
      * @since 1.9
-     *
      * @param array $parray
      * @param string $prefix
      * @return array
@@ -1433,7 +1452,6 @@ class Client implements DispatchableInterface
      * Separating this from send method allows subclasses to wrap
      * the interaction with the adapter
      *
-     * @param Http $uri
      * @param string $method
      * @param  bool $secure
      * @param array $headers
@@ -1471,6 +1489,7 @@ class Client implements DispatchableInterface
      * specified user, password and authentication method.
      *
      * @see http://www.faqs.org/rfcs/rfc2617.html
+     *
      * @param string $user
      * @param string $password
      * @param string $type

--- a/src/Client.php
+++ b/src/Client.php
@@ -343,7 +343,7 @@ class Client implements DispatchableInterface
             // reasons, see #4215 for a discussion - currently authentication is also
             // cleared for peer subdomains due to technical limits
             $nextHost = $this->getRequest()->getUri()->getHost();
-            if (! preg_match('/' . preg_quote($lastHost, '/') . '$/i', $nextHost)) {
+            if (! empty($lastHost) && ! preg_match('/' . preg_quote($lastHost, '/') . '$/i', $nextHost)) {
                 $this->clearAuth();
             }
 
@@ -914,7 +914,7 @@ class Client implements DispatchableInterface
 
                 if (! empty($queryArray)) {
                     $newUri      = $uri->toString();
-                    $queryString = http_build_query($queryArray, null, $this->getArgSeparator());
+                    $queryString = http_build_query($queryArray, '', $this->getArgSeparator());
 
                     if ($this->config['rfc3986strict']) {
                         $queryString = str_replace('+', '%20', $queryString);
@@ -1323,7 +1323,7 @@ class Client implements DispatchableInterface
                 $body .= '--' . $boundary . '--' . "\r\n";
             } elseif (stripos($this->getEncType(), self::ENC_URLENCODED) === 0) {
                 // Encode body as application/x-www-form-urlencoded
-                $body = http_build_query($this->getRequest()->getPost()->toArray(), null, '&');
+                $body = http_build_query($this->getRequest()->getPost()->toArray(), '', '&');
             } else {
                 throw new RuntimeException(sprintf(
                     'Cannot handle content type \'%s\' automatically',

--- a/src/Client/Adapter/AdapterInterface.php
+++ b/src/Client/Adapter/AdapterInterface.php
@@ -1,12 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Adapter;
+
+use Laminas\Uri\Uri;
 
 /**
  * An interface description for Laminas\Http\Client\Adapter classes.
@@ -36,7 +32,7 @@ interface AdapterInterface
      * Send request to the remote server
      *
      * @param string        $method
-     * @param \Laminas\Uri\Uri $url
+     * @param Uri $url
      * @param string        $httpVer
      * @param array         $headers
      * @param string        $body
@@ -53,7 +49,6 @@ interface AdapterInterface
 
     /**
      * Close the connection to the server
-     *
      */
     public function close();
 }

--- a/src/Client/Adapter/Exception/ExceptionInterface.php
+++ b/src/Client/Adapter/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Adapter\Exception;
 
 use Laminas\Http\Client\Exception\ExceptionInterface as HttpClientException;

--- a/src/Client/Adapter/Exception/InitializationException.php
+++ b/src/Client/Adapter/Exception/InitializationException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Adapter\Exception;
 
 class InitializationException extends RuntimeException

--- a/src/Client/Adapter/Exception/InvalidArgumentException.php
+++ b/src/Client/Adapter/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Adapter\Exception;
 
 use Laminas\Http\Client\Exception;

--- a/src/Client/Adapter/Exception/OutOfRangeException.php
+++ b/src/Client/Adapter/Exception/OutOfRangeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Adapter\Exception;
 
 use Laminas\Http\Client\Exception;

--- a/src/Client/Adapter/Exception/RuntimeException.php
+++ b/src/Client/Adapter/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Adapter\Exception;
 
 use Laminas\Http\Client\Exception;

--- a/src/Client/Adapter/Exception/TimeoutException.php
+++ b/src/Client/Adapter/Exception/TimeoutException.php
@@ -1,14 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Adapter\Exception;
 
 class TimeoutException extends RuntimeException implements ExceptionInterface
 {
-    const READ_TIMEOUT = 1000;
+    public const READ_TIMEOUT = 1000;
 }

--- a/src/Client/Adapter/Socket.php
+++ b/src/Client/Adapter/Socket.php
@@ -228,9 +228,10 @@ class Socket implements HttpAdapter, StreamInterface
     public function connect($host, $port = 80, $secure = false)
     {
         // If we are connected to the wrong host, disconnect first
-        $connectedHost = strpos($this->connectedTo[0], '://')
-            ? substr($this->connectedTo[0], strpos($this->connectedTo[0], '://') + 3, strlen($this->connectedTo[0]))
-            : $this->connectedTo[0];
+        $connectedTo   = $this->connectedTo[0] ?? '';
+        $connectedHost = strpos($connectedTo, '://')
+            ? substr($connectedTo, strpos($connectedTo, '://') + 3, strlen($this->connectedTo))
+            : $connectedTo;
 
         if ($connectedHost !== $host || $this->connectedTo[1] !== $port) {
             if (is_resource($this->socket)) {

--- a/src/Client/Adapter/Socket.php
+++ b/src/Client/Adapter/Socket.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Adapter;
 
 use Laminas\Http\Client\Adapter\AdapterInterface as HttpAdapter;
@@ -14,17 +8,50 @@ use Laminas\Http\Request;
 use Laminas\Http\Response;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\ErrorHandler;
+use Laminas\Uri\Uri;
 use Traversable;
 
+use function count;
+use function ctype_xdigit;
 use function extension_loaded;
+use function fclose;
+use function feof;
+use function fgets;
+use function fread;
+use function ftell;
+use function fwrite;
+use function get_resource_type;
+use function gettype;
+use function hexdec;
+use function is_array;
 use function is_dir;
 use function is_file;
+use function is_numeric;
+use function is_resource;
+use function is_string;
 use function openssl_error_string;
+use function rtrim;
 use function sprintf;
+use function str_ireplace;
+use function stream_context_create;
+use function stream_context_set_option;
+use function stream_copy_to_stream;
+use function stream_get_meta_data;
+use function stream_set_timeout;
+use function stream_socket_client;
 use function stream_socket_enable_crypto;
+use function strlen;
+use function strpos;
+use function strtolower;
+use function substr;
+use function trim;
 use function version_compare;
 
 use const PHP_VERSION;
+use const STREAM_CLIENT_CONNECT;
+use const STREAM_CLIENT_PERSISTENT;
+use const STREAM_CRYPTO_METHOD_SSLv23_CLIENT;
+use const STREAM_CRYPTO_METHOD_SSLv2_CLIENT;
 use const STREAM_CRYPTO_METHOD_SSLv3_CLIENT;
 use const STREAM_CRYPTO_METHOD_TLS_CLIENT;
 use const STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
@@ -76,16 +103,16 @@ class Socket implements HttpAdapter, StreamInterface
      * @var array
      */
     protected $config = [
-        'persistent'            => false,
-        'ssltransport'          => 'tls',
-        'sslcert'               => null,
-        'sslpassphrase'         => null,
-        'sslverifypeer'         => true,
-        'sslcafile'             => null,
-        'sslcapath'             => null,
-        'sslallowselfsigned'    => false,
-        'sslusecontext'         => false,
-        'sslverifypeername'     => true,
+        'persistent'         => false,
+        'ssltransport'       => 'tls',
+        'sslcert'            => null,
+        'sslpassphrase'      => null,
+        'sslverifypeer'      => true,
+        'sslcafile'          => null,
+        'sslcapath'          => null,
+        'sslallowselfsigned' => false,
+        'sslusecontext'      => false,
+        'sslverifypeername'  => true,
     ];
 
     /**
@@ -102,14 +129,11 @@ class Socket implements HttpAdapter, StreamInterface
      */
     protected $context;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $setSslCryptoMethod = true;
 
     /**
      * Adapter constructor, currently empty. Config is set using setOptions()
-     *
      */
     public function __construct()
     {
@@ -156,14 +180,13 @@ class Socket implements HttpAdapter, StreamInterface
      * will be created using the passed options.
      *
      * @since  Laminas 1.9
-     *
      * @param  mixed $context Stream context or array of context options
      * @throws Exception\InvalidArgumentException
      * @return $this
      */
     public function setStreamContext($context)
     {
-        if (is_resource($context) && get_resource_type($context) == 'stream-context') {
+        if (is_resource($context) && get_resource_type($context) === 'stream-context') {
             $this->context = $context;
         } elseif (is_array($context)) {
             $this->context = stream_context_create($context);
@@ -205,11 +228,11 @@ class Socket implements HttpAdapter, StreamInterface
     public function connect($host, $port = 80, $secure = false)
     {
         // If we are connected to the wrong host, disconnect first
-        $connectedHost = (strpos($this->connectedTo[0], '://'))
-            ? substr($this->connectedTo[0], (strpos($this->connectedTo[0], '://') + 3), strlen($this->connectedTo[0]))
+        $connectedHost = strpos($this->connectedTo[0], '://')
+            ? substr($this->connectedTo[0], strpos($this->connectedTo[0], '://') + 3, strlen($this->connectedTo[0]))
             : $this->connectedTo[0];
 
-        if ($connectedHost != $host || $this->connectedTo[1] != $port) {
+        if ($connectedHost !== $host || $this->connectedTo[1] !== $port) {
             if (is_resource($this->socket)) {
                 $this->close();
             }
@@ -239,12 +262,14 @@ class Socket implements HttpAdapter, StreamInterface
                 }
 
                 if ($this->config['sslallowselfsigned'] !== null) {
-                    if (! stream_context_set_option(
-                        $context,
-                        'ssl',
-                        'allow_self_signed',
-                        $this->config['sslallowselfsigned']
-                    )) {
+                    if (
+                        ! stream_context_set_option(
+                            $context,
+                            'ssl',
+                            'allow_self_signed',
+                            $this->config['sslallowselfsigned']
+                        )
+                    ) {
                         throw new AdapterException\RuntimeException('Unable to set sslallowselfsigned option');
                     }
                 }
@@ -262,12 +287,14 @@ class Socket implements HttpAdapter, StreamInterface
                 }
 
                 if ($this->config['sslverifypeername'] !== null) {
-                    if (! stream_context_set_option(
-                        $context,
-                        'ssl',
-                        'verify_peer_name',
-                        $this->config['sslverifypeername']
-                    )) {
+                    if (
+                        ! stream_context_set_option(
+                            $context,
+                            'ssl',
+                            'verify_peer_name',
+                            $this->config['sslverifypeername']
+                        )
+                    ) {
                         throw new AdapterException\RuntimeException('Unable to set sslverifypeername option');
                     }
                 }
@@ -300,7 +327,7 @@ class Socket implements HttpAdapter, StreamInterface
                 $flags,
                 $context
             );
-            $error = ErrorHandler::stop();
+            $error        = ErrorHandler::stop();
 
             if (! $this->socket) {
                 $this->close();
@@ -309,7 +336,7 @@ class Socket implements HttpAdapter, StreamInterface
                         'Unable to connect to %s:%d%s',
                         $host,
                         $port,
-                        ($error ? ' . Error #' . $error->getCode() . ': ' . $error->getMessage() : '')
+                        $error ? ' . Error #' . $error->getCode() . ': ' . $error->getMessage() : ''
                     ),
                     0,
                     $error
@@ -357,10 +384,11 @@ class Socket implements HttpAdapter, StreamInterface
         // We can do this because STREAM_CRYPTO_METHOD_TLS_ANY_CLIENT is available
         // in enum but not registered as php constant.
         // @see  https://github.com/php/php-src/blob/php-5.6.7/main/streams/php_stream_transport.h#L179
-        if (version_compare(PHP_VERSION, '7.2.0', '<')
+        if (
+            version_compare(PHP_VERSION, '7.2.0', '<')
             && $sslCryptoMethod === STREAM_CRYPTO_METHOD_TLS_CLIENT
         ) {
-            $sslCryptoMethod = STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
+            $sslCryptoMethod  = STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
             $sslCryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
             $sslCryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
         }
@@ -371,7 +399,7 @@ class Socket implements HttpAdapter, StreamInterface
             // Error handling is kind of difficult when it comes to SSL
             $errorString = '';
             if (extension_loaded('openssl')) {
-                while (($sslError = openssl_error_string()) != false) {
+                while (($sslError = openssl_error_string()) !== false) {
                     $errorString .= sprintf('; SSL error: %s', $sslError);
                 }
             }
@@ -410,7 +438,7 @@ class Socket implements HttpAdapter, StreamInterface
      * Send request to the remote server
      *
      * @param string        $method
-     * @param \Laminas\Uri\Uri $uri
+     * @param Uri $uri
      * @param string        $httpVer
      * @param array         $headers
      * @param string        $body
@@ -425,8 +453,8 @@ class Socket implements HttpAdapter, StreamInterface
         }
 
         $host = $uri->getHost();
-        $host = (strtolower($uri->getScheme()) == 'https' ? $this->config['ssltransport'] : 'tcp') . '://' . $host;
-        if ($this->connectedTo[0] != $host || $this->connectedTo[1] != $uri->getPort()) {
+        $host = (strtolower($uri->getScheme()) === 'https' ? $this->config['ssltransport'] : 'tcp') . '://' . $host;
+        if ($this->connectedTo[0] !== $host || $this->connectedTo[1] !== $uri->getPort()) {
             throw new AdapterException\RuntimeException('Trying to write but we are connected to the wrong host');
         }
 
@@ -434,9 +462,9 @@ class Socket implements HttpAdapter, StreamInterface
         $this->method = $method;
 
         // Build request headers
-        $path = $uri->getPath();
-        $query = $uri->getQuery();
-        $path .= $query ? '?' . $query : '';
+        $path    = $uri->getPath();
+        $query   = $uri->getQuery();
+        $path   .= $query ? '?' . $query : '';
         $request = $method . ' ' . $path . ' HTTP/' . $httpVer . "\r\n";
         foreach ($headers as $k => $v) {
             if (is_string($k)) {
@@ -461,7 +489,7 @@ class Socket implements HttpAdapter, StreamInterface
         }
 
         if (is_resource($body)) {
-            if (stream_copy_to_stream($body, $this->socket) == 0) {
+            if (stream_copy_to_stream($body, $this->socket) === 0) {
                 throw new AdapterException\RuntimeException('Error writing request to server');
             }
         }
@@ -478,7 +506,7 @@ class Socket implements HttpAdapter, StreamInterface
     public function read()
     {
         // First, read headers only
-        $response = '';
+        $response  = '';
         $gotStatus = false;
 
         while (($line = fgets($this->socket)) !== false) {
@@ -498,7 +526,7 @@ class Socket implements HttpAdapter, StreamInterface
         $statusCode = $responseObj->getStatusCode();
 
         // Handle 100 and 101 responses internally by restarting the read again
-        if ($statusCode == 100 || $statusCode == 101) {
+        if ($statusCode === 100 || $statusCode === 101) {
             return $this->read();
         }
 
@@ -509,13 +537,14 @@ class Socket implements HttpAdapter, StreamInterface
          * Responses to HEAD requests and 204 or 304 responses are not expected
          * to have a body - stop reading here
          */
-        if ($statusCode == 304
-            || $statusCode == 204
-            || $this->method == Request::METHOD_HEAD
+        if (
+            $statusCode === 304
+            || $statusCode === 204
+            || $this->method === Request::METHOD_HEAD
         ) {
             // Close the connection if requested to do so by the server
             $connection = $headers->get('connection');
-            if ($connection && $connection->getFieldValue() == 'close') {
+            if ($connection && $connection->getFieldValue() === 'close') {
                 $this->close();
             }
             return $response;
@@ -523,11 +552,11 @@ class Socket implements HttpAdapter, StreamInterface
 
         // If we got a 'transfer-encoding: chunked' header
         $transferEncoding = $headers->get('transfer-encoding');
-        $contentLength = $headers->get('content-length');
+        $contentLength    = $headers->get('content-length');
         if ($transferEncoding !== false) {
-            if (strtolower($transferEncoding->getFieldValue()) == 'chunked') {
+            if (strtolower($transferEncoding->getFieldValue()) === 'chunked') {
                 do {
-                    $line  = fgets($this->socket);
+                    $line = fgets($this->socket);
                     $this->_checkSocketReadTimeout();
 
                     $chunk = $line;
@@ -555,7 +584,7 @@ class Socket implements HttpAdapter, StreamInterface
                         }
 
                         if ($this->outStream) {
-                            if (stream_copy_to_stream($this->socket, $this->outStream, $readTo - $currentPos) == 0) {
+                            if (stream_copy_to_stream($this->socket, $this->outStream, $readTo - $currentPos) === 0) {
                                 $this->_checkSocketReadTimeout();
                                 break;
                             }
@@ -602,11 +631,13 @@ class Socket implements HttpAdapter, StreamInterface
 
             $currentPos = ftell($this->socket);
 
-            for ($readTo = $currentPos + $contentLength;
+            for (
+                $readTo = $currentPos + $contentLength;
                  $readTo > $currentPos;
-                 $currentPos = ftell($this->socket)) {
+                 $currentPos = ftell($this->socket)
+            ) {
                 if ($this->outStream) {
-                    if (stream_copy_to_stream($this->socket, $this->outStream, $readTo - $currentPos) == 0) {
+                    if (stream_copy_to_stream($this->socket, $this->outStream, $readTo - $currentPos) === 0) {
                         $this->_checkSocketReadTimeout();
                         break;
                     }
@@ -630,7 +661,7 @@ class Socket implements HttpAdapter, StreamInterface
         } else {
             do {
                 if ($this->outStream) {
-                    if (stream_copy_to_stream($this->socket, $this->outStream) == 0) {
+                    if (stream_copy_to_stream($this->socket, $this->outStream) === 0) {
                         $this->_checkSocketReadTimeout();
                         break;
                     }
@@ -650,7 +681,7 @@ class Socket implements HttpAdapter, StreamInterface
 
         // Close the connection if requested to do so by the server
         $connection = $headers->get('connection');
-        if ($connection && $connection->getFieldValue() == 'close') {
+        if ($connection && $connection->getFieldValue() === 'close') {
             $this->close();
         }
 
@@ -659,7 +690,6 @@ class Socket implements HttpAdapter, StreamInterface
 
     /**
      * Close the connection to the server
-     *
      */
     public function close()
     {
@@ -668,7 +698,7 @@ class Socket implements HttpAdapter, StreamInterface
             fclose($this->socket);
             ErrorHandler::stop();
         }
-        $this->socket = null;
+        $this->socket      = null;
         $this->connectedTo = [null, null];
     }
 
@@ -683,7 +713,7 @@ class Socket implements HttpAdapter, StreamInterface
     {
         // @codingStandardsIgnoreEnd
         if ($this->socket) {
-            $info = stream_get_meta_data($this->socket);
+            $info     = stream_get_meta_data($this->socket);
             $timedout = $info['timed_out'];
             if ($timedout) {
                 $this->close();
@@ -699,7 +729,7 @@ class Socket implements HttpAdapter, StreamInterface
      * Set output stream for the response
      *
      * @param resource $stream
-     * @return \Laminas\Http\Client\Adapter\Socket
+     * @return Socket
      */
     public function setOutputStream($stream)
     {
@@ -711,7 +741,6 @@ class Socket implements HttpAdapter, StreamInterface
      * Destructor: make sure the socket is disconnected
      *
      * If we are in persistent TCP mode, will not close the connection
-     *
      */
     public function __destruct()
     {

--- a/src/Client/Adapter/Socket.php
+++ b/src/Client/Adapter/Socket.php
@@ -230,7 +230,7 @@ class Socket implements HttpAdapter, StreamInterface
         // If we are connected to the wrong host, disconnect first
         $connectedTo   = $this->connectedTo[0] ?? '';
         $connectedHost = strpos($connectedTo, '://')
-            ? substr($connectedTo, strpos($connectedTo, '://') + 3, strlen($this->connectedTo))
+            ? substr($connectedTo, strpos($connectedTo, '://') + 3, strlen($connectedTo))
             : $connectedTo;
 
         if ($connectedHost !== $host || $this->connectedTo[1] !== $port) {

--- a/src/Client/Adapter/StreamInterface.php
+++ b/src/Client/Adapter/StreamInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Adapter;
 
 /**
@@ -21,7 +15,6 @@ interface StreamInterface
      * This function sets output stream where the result will be stored.
      *
      * @param resource $stream Stream to write the output to
-     *
      */
     public function setOutputStream($stream);
 }

--- a/src/Client/Adapter/Test.php
+++ b/src/Client/Adapter/Test.php
@@ -1,16 +1,17 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Adapter;
 
 use Laminas\Http\Response;
 use Laminas\Stdlib\ArrayUtils;
+use Laminas\Uri\Uri;
 use Traversable;
+
+use function count;
+use function gettype;
+use function is_array;
+use function is_string;
+use function strtolower;
 
 /**
  * A testing-purposes adapter.
@@ -62,7 +63,7 @@ class Test implements AdapterInterface
      * Set the nextRequestWillFail flag
      *
      * @param  bool $flag
-     * @return \Laminas\Http\Client\Adapter\Test
+     * @return Test
      */
     public function setNextRequestWillFail($flag)
     {
@@ -94,7 +95,6 @@ class Test implements AdapterInterface
         }
     }
 
-
     /**
      * Connect to the remote server
      *
@@ -115,7 +115,7 @@ class Test implements AdapterInterface
      * Send request to the remote server
      *
      * @param string        $method
-     * @param \Laminas\Uri\Uri $uri
+     * @param Uri $uri
      * @param string        $httpVer
      * @param array         $headers
      * @param string        $body
@@ -128,8 +128,8 @@ class Test implements AdapterInterface
         if (empty($path)) {
             $path = '/';
         }
-        $query = $uri->getQuery();
-        $path .= $query ? '?' . $query : '';
+        $query   = $uri->getQuery();
+        $path   .= $query ? '?' . $query : '';
         $request = $method . ' ' . $path . ' HTTP/' . $httpVer . "\r\n";
         foreach ($headers as $k => $v) {
             if (is_string($k)) {
@@ -161,7 +161,6 @@ class Test implements AdapterInterface
 
     /**
      * Close the connection (dummy)
-     *
      */
     public function close()
     {
@@ -170,7 +169,7 @@ class Test implements AdapterInterface
     /**
      * Set the HTTP response(s) to be returned by this adapter
      *
-     * @param \Laminas\Http\Response|array|string $response
+     * @param Response|array|string $response
      */
     public function setResponse($response)
     {
@@ -178,7 +177,7 @@ class Test implements AdapterInterface
             $response = $response->toString();
         }
 
-        $this->responses = (array) $response;
+        $this->responses     = (array) $response;
         $this->responseIndex = 0;
     }
 

--- a/src/Client/Exception/ExceptionInterface.php
+++ b/src/Client/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Exception;
 
 use Laminas\Http\Exception\ExceptionInterface as HttpException;

--- a/src/Client/Exception/InvalidArgumentException.php
+++ b/src/Client/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Exception;
 
 use Laminas\Http\Exception;

--- a/src/Client/Exception/OutOfRangeException.php
+++ b/src/Client/Exception/OutOfRangeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Exception;
 
 use Laminas\Http\Exception;

--- a/src/Client/Exception/RuntimeException.php
+++ b/src/Client/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Exception;
 
 use Laminas\Http\Exception;

--- a/src/ClientStatic.php
+++ b/src/ClientStatic.php
@@ -1,21 +1,15 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http;
+
+use function is_array;
 
 /**
  * Http static client
  */
 class ClientStatic
 {
-    /**
-     * @var Client
-     */
+    /** @var Client */
     protected static $client;
 
     /**

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -1,16 +1,20 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http;
 
 use ArrayIterator;
 use Laminas\Http\Header\SetCookie;
+use Laminas\Http\Headers;
 use Laminas\Uri;
+
+use function array_keys;
+use function array_merge;
+use function count;
+use function is_array;
+use function is_string;
+use function sprintf;
+use function strrpos;
+use function substr;
 
 /**
  * A Laminas\Http\Cookies object is designed to contain and maintain HTTP cookies, and should
@@ -35,50 +39,44 @@ class Cookies extends Headers
     /**
      * Return cookie(s) as a Laminas\Http\Cookie object
      */
-    const COOKIE_OBJECT = 0;
+    public const COOKIE_OBJECT = 0;
 
     /**
      * Return cookie(s) as a string (suitable for sending in an HTTP request)
      */
-    const COOKIE_STRING_ARRAY = 1;
+    public const COOKIE_STRING_ARRAY = 1;
 
     /**
      * Return all cookies as one long string (suitable for sending in an HTTP request)
      */
-    const COOKIE_STRING_CONCAT = 2;
+    public const COOKIE_STRING_CONCAT = 2;
 
     /**
      * Return all cookies as one long string (strict mode)
      *  - Single space after the semi-colon separating each cookie
      *  - Remove trailing semi-colon, if any
      */
-    const COOKIE_STRING_CONCAT_STRICT = 3;
+    public const COOKIE_STRING_CONCAT_STRICT = 3;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $cookies = [];
 
-    /**
-     * @var \Laminas\Http\Headers
-     */
+    /** @var Headers */
     protected $headers;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $rawCookies;
 
     /**
      * @static
      * @throws Exception\RuntimeException
-     * @param $string
+     * @param string $string
      * @return void
      */
     public static function fromString($string)
     {
         throw new Exception\RuntimeException(
-            __CLASS__ . '::' . __FUNCTION__ . ' should not be used as a factory, use '
+            self::class . '::' . __FUNCTION__ . ' should not be used as a factory, use '
             . __NAMESPACE__ . '\Headers::fromString() instead.'
         );
     }
@@ -107,7 +105,7 @@ class Cookies extends Headers
                 $this->cookies[$domain][$path] = [];
             }
             $this->cookies[$domain][$path][$cookie->getName()] = $cookie;
-            $this->rawCookies[] = $cookie;
+            $this->rawCookies[]                                = $cookie;
         } else {
             throw new Exception\InvalidArgumentException('Supplient argument is not a valid cookie string or object');
         }
@@ -116,7 +114,6 @@ class Cookies extends Headers
     /**
      * Parse an HTTP response, adding all the cookies set in that response
      *
-     * @param Response $response
      * @param Uri\Uri|string $refUri Requested URI
      */
     public function addCookiesFromResponse(Response $response, $refUri)
@@ -140,8 +137,7 @@ class Cookies extends Headers
      */
     public function getAllCookies($retAs = self::COOKIE_OBJECT)
     {
-        $cookies = $this->_flattenCookiesArray($this->cookies, $retAs);
-        return $cookies;
+        return $this->_flattenCookiesArray($this->cookies, $retAs);
     }
 
     /**
@@ -153,7 +149,7 @@ class Cookies extends Headers
      * @param bool $matchSessionCookies Whether to send session cookies
      * @param int $retAs Whether to return cookies as objects of \Laminas\Http\Header\Cookie or as strings
      * @param int $now Override the current time when checking for expiry time
-     * @throws Exception\InvalidArgumentException if invalid URI specified
+     * @throws Exception\InvalidArgumentException If invalid URI specified.
      * @return array|string
      */
     public function getMatchingCookies(
@@ -197,7 +193,7 @@ class Cookies extends Headers
      * @param Uri\Uri|string $uri The uri (domain and path) to match
      * @param string $cookieName The cookie's name
      * @param int $retAs Whether to return cookies as objects of \Laminas\Http\Header\SetCookie or as strings
-     * @throws Exception\InvalidArgumentException if invalid URI specified or invalid $retAs value
+     * @throws Exception\InvalidArgumentException If invalid URI specified or invalid $retAs value.
      * @return SetCookie|string
      */
     public function getCookie($uri, $cookieName, $retAs = self::COOKIE_OBJECT)
@@ -214,9 +210,9 @@ class Cookies extends Headers
         }
 
         // Get correct cookie path
-        $path = $uri->getPath();
+        $path         = $uri->getPath();
         $lastSlashPos = strrpos($path, '/') ?: 0;
-        $path = substr($path, 0, $lastSlashPos);
+        $path         = substr($path, 0, $lastSlashPos);
         if (! $path) {
             $path = '/';
         }
@@ -247,7 +243,7 @@ class Cookies extends Headers
      * Helper function to recursively flatten an array. Should be used when exporting the
      * cookies array (or parts of it)
      *
-     * @param \Laminas\Http\Header\SetCookie|array $ptr
+     * @param SetCookie|array $ptr
      * @param int $retAs What value to return
      * @return array|string
      */
@@ -256,9 +252,9 @@ class Cookies extends Headers
     {
         // @codingStandardsIgnoreEnd
         if (is_array($ptr)) {
-            $ret = ($retAs == self::COOKIE_STRING_CONCAT ? '' : []);
+            $ret = $retAs === self::COOKIE_STRING_CONCAT ? '' : [];
             foreach ($ptr as $item) {
-                if ($retAs == self::COOKIE_STRING_CONCAT) {
+                if ($retAs === self::COOKIE_STRING_CONCAT) {
                     $ret .= $this->_flattenCookiesArray($item, $retAs);
                 } else {
                     $ret = array_merge($ret, $this->_flattenCookiesArray($item, $retAs));
@@ -278,8 +274,6 @@ class Cookies extends Headers
                     return [$ptr];
             }
         }
-
-        return;
     }
 
     /**
@@ -356,7 +350,7 @@ class Cookies extends Headers
      */
     public function isEmpty()
     {
-        return count($this) == 0;
+        return count($this) === 0;
     }
 
     /**

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -210,7 +210,7 @@ class Cookies extends Headers
         }
 
         // Get correct cookie path
-        $path         = $uri->getPath();
+        $path         = $uri->getPath() ?? '';
         $lastSlashPos = strrpos($path, '/') ?: 0;
         $path         = substr($path, 0, $lastSlashPos);
         if (! $path) {

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Exception;
 
 interface ExceptionInterface

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements

--- a/src/Exception/OutOfRangeException.php
+++ b/src/Exception/OutOfRangeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Exception;
 
 class OutOfRangeException extends \OutOfRangeException implements ExceptionInterface

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Exception;
 
 class RuntimeException extends \RuntimeException implements

--- a/src/Header/AbstractAccept.php
+++ b/src/Header/AbstractAccept.php
@@ -194,7 +194,7 @@ abstract class AbstractAccept implements HeaderInterface
                     $value = substr(substr($value, 1), 0, -1);
                 }
 
-                $params[trim($explode[0])] = stripslashes($value);
+                $params[trim($explode[0])] = stripslashes($value ?? '');
             }
         }
 

--- a/src/Header/AbstractAccept.php
+++ b/src/Header/AbstractAccept.php
@@ -1,14 +1,32 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 use stdClass;
+
+use function array_intersect;
+use function array_shift;
+use function array_walk;
+use function count;
+use function explode;
+use function implode;
+use function is_float;
+use function is_int;
+use function is_numeric;
+use function is_string;
+use function preg_match;
+use function preg_match_all;
+use function preg_replace_callback;
+use function sprintf;
+use function str_split;
+use function stripslashes;
+use function strlen;
+use function strpos;
+use function strtolower;
+use function substr;
+use function trim;
+use function usort;
+use function version_compare;
 
 /**
  * Abstract Accept Header
@@ -31,17 +49,14 @@ use stdClass;
  *                                      |--|                   parameter value
  *                        |---|                                priority
  *
- *
  * @see        http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
- * @author     Dolf Schimmel - Freeaqingme
  */
 abstract class AbstractAccept implements HeaderInterface
 {
-    /**
-     * @var stdClass[]
-     */
+    /** @var stdClass[] */
     protected $fieldValueParts = [];
 
+    /** @var string */
     protected $regexAddType;
 
     /**
@@ -59,7 +74,7 @@ abstract class AbstractAccept implements HeaderInterface
     public function parseHeaderLine($headerLine)
     {
         if (strpos($headerLine, ':') !== false) {
-            list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+            [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
             if (strtolower($name) !== strtolower($this->getFieldName())) {
                 $value = $headerLine; // This is just for preserve the BC.
             }
@@ -91,13 +106,14 @@ abstract class AbstractAccept implements HeaderInterface
      * Parse the Field Value Parts represented by a header line
      *
      * @param string  $headerLine
-     * @throws Exception\InvalidArgumentException If header is invalid
+     * @throws Exception\InvalidArgumentException If header is invalid.
      * @return array
      */
     public function getFieldValuePartsFromHeaderLine($headerLine)
     {
         // process multiple accept values, they may be between quotes
-        if (! preg_match_all('/(?:[^,"]|"(?:[^\\\"]|\\\.)*")+/', $headerLine, $values)
+        if (
+            ! preg_match_all('/(?:[^,"]|"(?:[^\\\"]|\\\.)*")+/', $headerLine, $values)
                 || ! isset($values[0])
         ) {
             throw new Exception\InvalidArgumentException(
@@ -133,7 +149,7 @@ abstract class AbstractAccept implements HeaderInterface
             $fieldValuePart = trim(substr($fieldValuePart, 0, $pos));
         }
 
-        $format = '*';
+        $format  = '*';
         $subtype = '*';
 
         return (object) [
@@ -142,7 +158,7 @@ abstract class AbstractAccept implements HeaderInterface
             'subtype'    => $subtype,
             'subtypeRaw' => $subtypeWhole,
             'format'     => $format,
-            'priority'   => isset($params['q']) ? $params['q'] : 1,
+            'priority'   => $params['q'] ?? 1,
             'params'     => $params,
             'raw'        => trim($raw),
         ];
@@ -157,7 +173,7 @@ abstract class AbstractAccept implements HeaderInterface
     protected function getParametersFromFieldValuePart($fieldValuePart)
     {
         $params = [];
-        if ((($pos = strpos($fieldValuePart, ';')) !== false)) {
+        if (($pos = strpos($fieldValuePart, ';')) !== false) {
             preg_match_all('/(?:[^;"]|"(?:[^\\\"]|\\\.)*")+/', $fieldValuePart, $paramsStrings);
 
             if (isset($paramsStrings[0])) {
@@ -174,7 +190,7 @@ abstract class AbstractAccept implements HeaderInterface
                     $value = null;
                 }
 
-                if (isset($value[0]) && $value[0] == '"' && substr($value, -1) == '"') {
+                if (isset($value[0]) && $value[0] === '"' && substr($value, -1) === '"') {
                     $value = substr(substr($value, 1), 0, -1);
                 }
 
@@ -227,7 +243,7 @@ abstract class AbstractAccept implements HeaderInterface
             $value
         );
 
-        if ($escaped == $value && ! array_intersect(str_split($value), $separators)) {
+        if ($escaped === $value && ! array_intersect(str_split($value), $separators)) {
             $value = $key . ($value ? '=' . $value : '');
         } else {
             $value = $key . ($value ? '="' . $escaped . '"' : '');
@@ -255,7 +271,8 @@ abstract class AbstractAccept implements HeaderInterface
             ));
         }
 
-        if (! is_int($priority) && ! is_float($priority) && ! is_numeric($priority)
+        if (
+            ! is_int($priority) && ! is_float($priority) && ! is_numeric($priority)
             || $priority > 1 || $priority < 0
         ) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -265,7 +282,7 @@ abstract class AbstractAccept implements HeaderInterface
             ));
         }
 
-        if ($priority != 1) {
+        if ($priority !== 1) {
             $params = ['q' => sprintf('%01.1f', $priority)] + $params;
         }
 
@@ -303,7 +320,7 @@ abstract class AbstractAccept implements HeaderInterface
 
         foreach ($this->getPrioritized() as $left) {
             foreach ($matchAgainst as $right) {
-                if ($right->type == '*' || $left->type == '*') {
+                if ($right->type === '*' || $left->type === '*') {
                     if ($this->matchAcceptParams($left, $right)) {
                         $left->setMatchedAgainst($right);
 
@@ -311,9 +328,10 @@ abstract class AbstractAccept implements HeaderInterface
                     }
                 }
 
-                if ($left->type == $right->type) {
-                    if (($left->subtype == $right->subtype || ($right->subtype == '*' || $left->subtype == '*'))
-                        && ($left->format == $right->format || $right->format == '*' || $left->format == '*')
+                if ($left->type === $right->type) {
+                    if (
+                        ($left->subtype === $right->subtype || ($right->subtype === '*' || $left->subtype === '*'))
+                        && ($left->format === $right->format || $right->format === '*' || $left->format === '*')
                     ) {
                         if ($this->matchAcceptParams($left, $right)) {
                             $left->setMatchedAgainst($right);
@@ -346,7 +364,8 @@ abstract class AbstractAccept implements HeaderInterface
                         $pieces
                     );
 
-                    if (count($pieces) == 3
+                    if (
+                        count($pieces) === 3
                         && (version_compare($pieces[1], $match1->params[$key], '<=')
                             xor version_compare($pieces[2], $match1->params[$key], '>='))
                     ) {
@@ -354,9 +373,9 @@ abstract class AbstractAccept implements HeaderInterface
                     }
                 } elseif (strpos($value, '|')) {
                     $options = explode('|', $value);
-                    $good = false;
+                    $good    = false;
                     foreach ($options as $option) {
-                        if ($option == $match1->params[$key]) {
+                        if ($option === $match1->params[$key]) {
                             $good = true;
                             break;
                         }
@@ -365,7 +384,7 @@ abstract class AbstractAccept implements HeaderInterface
                     if (! $good) {
                         return false;
                     }
-                } elseif ($match1->params[$key] != $value) {
+                } elseif ($match1->params[$key] !== $value) {
                     return false;
                 }
             }
@@ -378,18 +397,18 @@ abstract class AbstractAccept implements HeaderInterface
      * Add a key/value combination to the internal queue
      *
      * @param stdClass $value
-     * @return number
+     * @return void
      */
     protected function addFieldValuePartToQueue($value)
     {
         $this->fieldValueParts[] = $value;
-        $this->sorted = false;
+        $this->sorted            = false;
     }
 
     /**
      * Sort the internal Field Value Parts
      *
-     * @See rfc2616 sect 14.1
+     * @see rfc2616 sect 14.1
      * Media ranges can be overridden by more specific media ranges or
      * specific media types. If more than one media range applies to a given
      * type, the most specific reference has precedence. For example,
@@ -403,11 +422,11 @@ abstract class AbstractAccept implements HeaderInterface
      * 3) text/*
      * 4) * /*
      *
-     * @return number
+     * @return void
      */
     protected function sortFieldValueParts()
     {
-        $sort = function ($a, $b) {
+        $sort = static function (object $a, object $b): int {
             // If A has higher precedence than B, return -1.
             if ($a->priority > $b->priority) {
                 return -1;
@@ -418,26 +437,26 @@ abstract class AbstractAccept implements HeaderInterface
             // Asterisks
             $values = ['type', 'subtype', 'format'];
             foreach ($values as $value) {
-                if ($a->$value == '*' && $b->$value != '*') {
+                if ($a->$value === '*' && $b->$value !== '*') {
                     return 1;
-                } elseif ($b->$value == '*' && $a->$value != '*') {
+                } elseif ($b->$value === '*' && $a->$value !== '*') {
                     return -1;
                 }
             }
 
-            if ($a->type == 'application' && $b->type != 'application') {
+            if ($a->type === 'application' && $b->type !== 'application') {
                 return -1;
-            } elseif ($b->type == 'application' && $a->type != 'application') {
+            } elseif ($b->type === 'application' && $a->type !== 'application') {
                 return 1;
             }
 
             // @todo count number of dots in case of type==application in subtype
 
             // So far they're still the same. Longest string length may be more specific
-            if (strlen($a->raw) == strlen($b->raw)) {
+            if (strlen($a->raw) === strlen($b->raw)) {
                 return 0;
             }
-            return (strlen($a->raw) > strlen($b->raw)) ? -1 : 1;
+            return strlen($a->raw) > strlen($b->raw) ? -1 : 1;
         };
 
         usort($this->fieldValueParts, $sort);

--- a/src/Header/AbstractDate.php
+++ b/src/Header/AbstractDate.php
@@ -1,15 +1,17 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use Laminas\Http\Header\Exception\InvalidArgumentException;
+
+use function is_numeric;
+use function is_string;
+use function sprintf;
+use function strtolower;
+use function strtotime;
 
 /**
  * Abstract Date/Time Header
@@ -29,11 +31,12 @@ abstract class AbstractDate implements HeaderInterface
 {
     /**
      * Date formats according to RFC 2616
+     *
      * @link http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3
      */
-    const DATE_RFC1123 = 0;
-    const DATE_RFC1036 = 1;
-    const DATE_ANSIC   = 2;
+    public const DATE_RFC1123 = 0;
+    public const DATE_RFC1036 = 1;
+    public const DATE_ANSIC   = 2;
 
     /**
      * Date instance for this header
@@ -52,6 +55,7 @@ abstract class AbstractDate implements HeaderInterface
     /**
      * Date formats defined by RFC 2616. RFC 1123 date is required
      * RFC 1036 and ANSI C formats are provided for compatibility with old servers/clients
+     *
      * @link http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3
      *
      * @var array
@@ -67,17 +71,17 @@ abstract class AbstractDate implements HeaderInterface
      *
      * @param string $headerLine
      * @return static
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public static function fromString($headerLine)
     {
         $dateHeader = new static();
 
-        list($name, $date) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $date] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== strtolower($dateHeader->getFieldName())) {
-            throw new Exception\InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Invalid header line for "' . $dateHeader->getFieldName() . '" header string'
             );
         }
@@ -92,7 +96,7 @@ abstract class AbstractDate implements HeaderInterface
      *
      * @param int|string $time
      * @return static
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public static function fromTimeString($time)
     {
@@ -104,14 +108,14 @@ abstract class AbstractDate implements HeaderInterface
      *
      * @param int $time
      * @return static
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public static function fromTimestamp($time)
     {
         $dateHeader = new static();
 
         if (! $time || ! is_numeric($time)) {
-            throw new Exception\InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Invalid time for "' . $dateHeader->getFieldName() . '" header string'
             );
         }
@@ -125,12 +129,12 @@ abstract class AbstractDate implements HeaderInterface
      * Set date output format
      *
      * @param int $format
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public static function setDateFormat($format)
     {
         if (! isset(static::$dateFormats[$format])) {
-            throw new Exception\InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'No constant defined for provided date format: %s',
                 $format
             ));
@@ -154,22 +158,22 @@ abstract class AbstractDate implements HeaderInterface
      *
      * @param string|DateTime $date
      * @return $this
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function setDate($date)
     {
         if (is_string($date)) {
             try {
                 $date = new DateTime($date, new DateTimeZone('GMT'));
-            } catch (\Exception $e) {
-                throw new Exception\InvalidArgumentException(
+            } catch (Exception $e) {
+                throw new InvalidArgumentException(
                     sprintf('Invalid date passed as string (%s)', (string) $date),
                     $e->getCode(),
                     $e
                 );
             }
-        } elseif (! ($date instanceof DateTime)) {
-            throw new Exception\InvalidArgumentException('Date must be an instance of \DateTime or a string');
+        } elseif (! $date instanceof DateTime) {
+            throw new InvalidArgumentException('Date must be an instance of \DateTime or a string');
         }
 
         $date->setTimezone(new DateTimeZone('GMT'));
@@ -204,32 +208,33 @@ abstract class AbstractDate implements HeaderInterface
     /**
      * Compare provided date to date for this header
      * Returns < 0 if date in header is less than $date; > 0 if it's greater, and 0 if they are equal.
+     *
      * @see \strcmp()
      *
      * @param string|DateTime $date
      * @return int
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function compareTo($date)
     {
         if (is_string($date)) {
             try {
                 $date = new DateTime($date, new DateTimeZone('GMT'));
-            } catch (\Exception $e) {
-                throw new Exception\InvalidArgumentException(
+            } catch (Exception $e) {
+                throw new InvalidArgumentException(
                     sprintf('Invalid Date passed as string (%s)', (string) $date),
                     $e->getCode(),
                     $e
                 );
             }
-        } elseif (! ($date instanceof DateTime)) {
-            throw new Exception\InvalidArgumentException('Date must be an instance of \DateTime or a string');
+        } elseif (! $date instanceof DateTime) {
+            throw new InvalidArgumentException('Date must be an instance of \DateTime or a string');
         }
 
         $dateTimestamp = $date->getTimestamp();
         $thisTimestamp = $this->date()->getTimestamp();
 
-        return ($thisTimestamp === $dateTimestamp) ? 0 : (($thisTimestamp > $dateTimestamp) ? 1 : -1);
+        return $thisTimestamp === $dateTimestamp ? 0 : ($thisTimestamp > $dateTimestamp ? 1 : -1);
     }
 
     /**

--- a/src/Header/AbstractDate.php
+++ b/src/Header/AbstractDate.php
@@ -200,7 +200,7 @@ abstract class AbstractDate implements HeaderInterface
     public function date()
     {
         if ($this->date === null) {
-            $this->date = new DateTime(null, new DateTimeZone('GMT'));
+            $this->date = new DateTime('now', new DateTimeZone('GMT'));
         }
         return $this->date;
     }

--- a/src/Header/AbstractLocation.php
+++ b/src/Header/AbstractLocation.php
@@ -1,20 +1,20 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 use Laminas\Uri\Exception as UriException;
 use Laminas\Uri\UriFactory;
 use Laminas\Uri\UriInterface;
 
+use function is_string;
+use function sprintf;
+use function strtolower;
+use function trim;
+
 /**
  * Abstract Location Header
  * Supports headers that have URI as value
+ *
  * @see Laminas\Http\Header\Location
  * @see Laminas\Http\Header\ContentLocation
  * @see Laminas\Http\Header\Referer
@@ -44,7 +44,7 @@ abstract class AbstractLocation implements HeaderInterface
         $locationHeader = new static();
 
         // Laminas-5520 - IIS bug, no space after colon
-        list($name, $uri) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $uri] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== strtolower($locationHeader->getFieldName())) {
@@ -84,7 +84,7 @@ abstract class AbstractLocation implements HeaderInterface
                     $e
                 );
             }
-        } elseif (! ($uri instanceof UriInterface)) {
+        } elseif (! $uri instanceof UriInterface) {
             throw new Exception\InvalidArgumentException('URI must be an instance of Laminas\Uri\Http or a string');
         }
         $this->uri = $uri;

--- a/src/Header/Accept.php
+++ b/src/Header/Accept.php
@@ -1,14 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 use Laminas\Http\Header\Accept\FieldValuePart;
+
+use function strpos;
+use function substr;
+use function trim;
 
 /**
  * Accept Header
@@ -17,9 +15,7 @@ use Laminas\Http\Header\Accept\FieldValuePart;
  */
 class Accept extends AbstractAccept
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $regexAddType = '#^([a-zA-Z+-]+|\*)/(\*|[a-zA-Z0-9+-]+)$#';
 
     /**
@@ -69,9 +65,10 @@ class Accept extends AbstractAccept
     /**
      * Parse the keys contained in the header line
      *
+     * @see    \Laminas\Http\Header\AbstractAccept::parseFieldValuePart()
+     *
      * @param  string $fieldValuePart
      * @return FieldValuePart\AcceptFieldValuePart
-     * @see    \Laminas\Http\Header\AbstractAccept::parseFieldValuePart()
      */
     protected function parseFieldValuePart($fieldValuePart)
     {
@@ -92,13 +89,13 @@ class Accept extends AbstractAccept
             $subtypeWhole = $format = $subtype = trim(substr($fieldValuePart, strpos($fieldValuePart, '/') + 1));
         } else {
             $subtypeWhole = '';
-            $format = '*';
-            $subtype = '*';
+            $format       = '*';
+            $subtype      = '*';
         }
 
         $pos = strpos($subtype, '+');
         if (false !== $pos) {
-            $format = trim(substr($subtype, $pos + 1));
+            $format  = trim(substr($subtype, $pos + 1));
             $subtype = trim(substr($subtype, 0, $pos));
         }
 
@@ -108,7 +105,7 @@ class Accept extends AbstractAccept
             'subtype'    => $subtype,
             'subtypeRaw' => $subtypeWhole,
             'format'     => $format,
-            'priority'   => isset($params['q']) ? $params['q'] : 1,
+            'priority'   => $params['q'] ?? 1,
             'params'     => $params,
             'raw'        => trim($raw),
         ];

--- a/src/Header/Accept/FieldValuePart/AbstractFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/AbstractFieldValuePart.php
@@ -1,12 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header\Accept\FieldValuePart;
+
+use stdClass;
 
 /**
  * Field Value Part
@@ -17,12 +13,14 @@ abstract class AbstractFieldValuePart
 {
     /**
      * Internal object used for value retrieval
+     *
      * @var object
      */
     private $internalValues;
 
     /**
      * A Field Value Part this Field Value Part matched against.
+     *
      * @var AbstractFieldValuePart
      */
     protected $matchedAgainst;
@@ -38,7 +36,6 @@ abstract class AbstractFieldValuePart
     /**
      * Set a Field Value Part this Field Value Part matched against.
      *
-     * @param AbstractFieldValuePart $matchedAgainst
      * @return $this
      */
     public function setMatchedAgainst(AbstractFieldValuePart $matchedAgainst)
@@ -82,7 +79,7 @@ abstract class AbstractFieldValuePart
     }
 
     /**
-     * @return \stdClass $params
+     * @return stdClass $params
      */
     public function getParams()
     {

--- a/src/Header/Accept/FieldValuePart/AcceptFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/AcceptFieldValuePart.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header\Accept\FieldValuePart;
 
 /**

--- a/src/Header/Accept/FieldValuePart/CharsetFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/CharsetFieldValuePart.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header\Accept\FieldValuePart;
 
 /**

--- a/src/Header/Accept/FieldValuePart/EncodingFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/EncodingFieldValuePart.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header\Accept\FieldValuePart;
 
 /**

--- a/src/Header/Accept/FieldValuePart/LanguageFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/LanguageFieldValuePart.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header\Accept\FieldValuePart;
 
 /**
@@ -15,16 +9,19 @@ namespace Laminas\Http\Header\Accept\FieldValuePart;
  */
 class LanguageFieldValuePart extends AbstractFieldValuePart
 {
+    /** @return string */
     public function getLanguage()
     {
         return $this->getInternalValues()->typeString;
     }
 
+    /** @return string */
     public function getPrimaryTag()
     {
         return $this->getInternalValues()->type;
     }
 
+    /** @return string */
     public function getSubTag()
     {
         return $this->getInternalValues()->subtype;

--- a/src/Header/AcceptCharset.php
+++ b/src/Header/AcceptCharset.php
@@ -1,14 +1,9 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 use Laminas\Http\Header\Accept\FieldValuePart;
+use Laminas\Http\Header\Accept\FieldValuePart\CharsetFieldValuePart;
 
 /**
  * Accept Charset Header
@@ -17,6 +12,7 @@ use Laminas\Http\Header\Accept\FieldValuePart;
  */
 class AcceptCharset extends AbstractAccept
 {
+    /** @var string */
     protected $regexAddType = '#^([a-zA-Z0-9+-]+|\*)$#';
 
     /**
@@ -65,9 +61,10 @@ class AcceptCharset extends AbstractAccept
     /**
      * Parse the keys contained in the header line
      *
-     * @param string $fieldValuePart
-     * @return \Laminas\Http\Header\Accept\FieldValuePart\CharsetFieldValuePart
      * @see \Laminas\Http\Header\AbstractAccept::parseFieldValuePart()
+     *
+     * @param string $fieldValuePart
+     * @return CharsetFieldValuePart
      */
     protected function parseFieldValuePart($fieldValuePart)
     {

--- a/src/Header/AcceptEncoding.php
+++ b/src/Header/AcceptEncoding.php
@@ -1,14 +1,9 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 use Laminas\Http\Header\Accept\FieldValuePart;
+use Laminas\Http\Header\Accept\FieldValuePart\EncodingFieldValuePart;
 
 /**
  * Accept Encoding Header
@@ -17,6 +12,7 @@ use Laminas\Http\Header\Accept\FieldValuePart;
  */
 class AcceptEncoding extends AbstractAccept
 {
+    /** @var string */
     protected $regexAddType = '#^([a-zA-Z0-9+-]+|\*)$#';
 
     /**
@@ -65,9 +61,10 @@ class AcceptEncoding extends AbstractAccept
     /**
      * Parse the keys contained in the header line
      *
-     * @param string $fieldValuePart
-     * @return \Laminas\Http\Header\Accept\FieldValuePart\EncodingFieldValuePart
      * @see \Laminas\Http\Header\AbstractAccept::parseFieldValuePart()
+     *
+     * @param string $fieldValuePart
+     * @return EncodingFieldValuePart
      */
     protected function parseFieldValuePart($fieldValuePart)
     {

--- a/src/Header/AcceptLanguage.php
+++ b/src/Header/AcceptLanguage.php
@@ -1,14 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 use Laminas\Http\Header\Accept\FieldValuePart;
+use Laminas\Http\Header\Accept\FieldValuePart\LanguageFieldValuePart;
+
+use function strpos;
+use function substr;
+use function trim;
 
 /**
  * Accept Language Header
@@ -17,6 +16,7 @@ use Laminas\Http\Header\Accept\FieldValuePart;
  */
 class AcceptLanguage extends AbstractAccept
 {
+    /** @var string */
     protected $regexAddType = '#^([a-zA-Z0-9+-]+|\*)$#';
 
     /**
@@ -65,9 +65,10 @@ class AcceptLanguage extends AbstractAccept
     /**
      * Parse the keys contained in the header line
      *
-     * @param string $fieldValuePart
-     * @return \Laminas\Http\Header\Accept\FieldValuePart\LanguageFieldValuePart
      * @see \Laminas\Http\Header\AbstractAccept::parseFieldValuePart()
+     *
+     * @param string $fieldValuePart
+     * @return LanguageFieldValuePart
      */
     protected function parseFieldValuePart($fieldValuePart)
     {
@@ -88,8 +89,8 @@ class AcceptLanguage extends AbstractAccept
             $subtypeWhole = $format = $subtype = trim(substr($fieldValuePart, strpos($fieldValuePart, '-') + 1));
         } else {
             $subtypeWhole = '';
-            $format = '*';
-            $subtype = '*';
+            $format       = '*';
+            $subtype      = '*';
         }
 
         $aggregated = [
@@ -98,7 +99,7 @@ class AcceptLanguage extends AbstractAccept
             'subtype'    => $subtype,
             'subtypeRaw' => $subtypeWhole,
             'format'     => $format,
-            'priority'   => isset($params['q']) ? $params['q'] : 1,
+            'priority'   => $params['q'] ?? 1,
             'params'     => $params,
             'raw'        => trim($raw),
         ];

--- a/src/Header/AcceptRanges.php
+++ b/src/Header/AcceptRanges.php
@@ -1,12 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function strtolower;
 
 /**
  * Accept Ranges Header
@@ -15,11 +11,16 @@ namespace Laminas\Http\Header;
  */
 class AcceptRanges implements HeaderInterface
 {
+    /** @var null|string */
     protected $rangeUnit;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'accept-ranges') {
@@ -31,6 +32,7 @@ class AcceptRanges implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $rangeUnit */
     public function __construct($rangeUnit = null)
     {
         if ($rangeUnit !== null) {
@@ -38,16 +40,22 @@ class AcceptRanges implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Accept-Ranges';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return $this->getRangeUnit();
     }
 
+    /**
+     * @param string $rangeUnit
+     * @return static
+     */
     public function setRangeUnit($rangeUnit)
     {
         HeaderValue::assertValid($rangeUnit);
@@ -55,11 +63,13 @@ class AcceptRanges implements HeaderInterface
         return $this;
     }
 
+    /** @return string */
     public function getRangeUnit()
     {
         return (string) $this->rangeUnit;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Accept-Ranges: ' . $this->getFieldValue();

--- a/src/Header/Age.php
+++ b/src/Header/Age.php
@@ -1,12 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function is_int;
+use function is_numeric;
+use function strtolower;
+
+use const PHP_INT_MAX;
 
 /**
  * Age HTTP Header
@@ -31,7 +31,7 @@ class Age implements HeaderInterface
      */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'age') {
@@ -41,6 +41,7 @@ class Age implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|int $deltaSeconds */
     public function __construct($deltaSeconds = null)
     {
         if ($deltaSeconds !== null) {
@@ -101,6 +102,6 @@ class Age implements HeaderInterface
      */
     public function toString()
     {
-        return 'Age: ' . (($this->deltaSeconds >= PHP_INT_MAX) ? '2147483648' : $this->deltaSeconds);
+        return 'Age: ' . ($this->deltaSeconds >= PHP_INT_MAX ? '2147483648' : $this->deltaSeconds);
     }
 }

--- a/src/Header/Allow.php
+++ b/src/Header/Allow.php
@@ -1,14 +1,17 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 use Laminas\Http\Request;
+
+use function array_keys;
+use function explode;
+use function implode;
+use function preg_match;
+use function sprintf;
+use function strtolower;
+use function strtoupper;
+use function trim;
 
 /**
  * Allow Header
@@ -45,7 +48,7 @@ class Allow implements HeaderInterface
      */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'allow') {

--- a/src/Header/AuthenticationInfo.php
+++ b/src/Header/AuthenticationInfo.php
@@ -1,27 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.ietf.org/rfc/rfc2617.txt
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class AuthenticationInfo implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'authentication-info') {
@@ -35,6 +35,7 @@ class AuthenticationInfo implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -43,16 +44,19 @@ class AuthenticationInfo implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Authentication-Info';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Authentication-Info: ' . $this->getFieldValue();

--- a/src/Header/Authorization.php
+++ b/src/Header/Authorization.php
@@ -1,27 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.8
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Authorization implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'authorization') {
@@ -35,6 +35,7 @@ class Authorization implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -43,16 +44,19 @@ class Authorization implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Authorization';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Authorization: ' . $this->getFieldValue();

--- a/src/Header/CacheControl.php
+++ b/src/Header/CacheControl.php
@@ -1,22 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function array_key_exists;
+use function implode;
+use function is_bool;
+use function ksort;
+use function preg_match;
+use function rtrim;
+use function sprintf;
+use function strlen;
+use function strtolower;
+use function substr;
+use function trim;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class CacheControl implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
     /**
@@ -35,7 +40,7 @@ class CacheControl implements HeaderInterface
      */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'cache-control') {
@@ -177,11 +182,13 @@ class CacheControl implements HeaderInterface
         $directives = [];
 
         // handle empty string early so we don't need a separate start state
-        if ($value == '') {
+        if ($value === '') {
             return $directives;
         }
 
         $lastMatch = null;
+
+        // phpcs:disable Generic.PHP.DiscourageGoto.Found
 
         state_directive:
         switch (static::match(['[a-zA-Z][a-zA-Z_-]*'], $value, $lastMatch)) {
@@ -223,6 +230,8 @@ class CacheControl implements HeaderInterface
             default:
                 throw new Exception\InvalidArgumentException('expected SEPARATOR or END');
         }
+
+        // phpcs:enable
     }
 
     /**
@@ -241,7 +250,7 @@ class CacheControl implements HeaderInterface
         foreach ($tokens as $i => $token) {
             if (preg_match('/^' . $token . '/', $value, $matches)) {
                 $lastMatch = $matches[0];
-                $string = substr($value, strlen($matches[0]));
+                $string    = substr($value, strlen($matches[0]));
                 return $i;
             }
         }

--- a/src/Header/Connection.php
+++ b/src/Header/Connection.php
@@ -1,12 +1,9 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function strtolower;
+use function trim;
 
 /**
  * Connection Header
@@ -15,8 +12,8 @@ namespace Laminas\Http\Header;
  */
 class Connection implements HeaderInterface
 {
-    const CONNECTION_CLOSE      = 'close';
-    const CONNECTION_KEEP_ALIVE = 'keep-alive';
+    public const CONNECTION_CLOSE      = 'close';
+    public const CONNECTION_KEEP_ALIVE = 'keep-alive';
 
     /**
      * Value of this header
@@ -34,7 +31,7 @@ class Connection implements HeaderInterface
     {
         $header = new static();
 
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'connection') {
@@ -67,7 +64,7 @@ class Connection implements HeaderInterface
      */
     public function isPersistent()
     {
-        return ($this->value === self::CONNECTION_KEEP_ALIVE);
+        return $this->value === self::CONNECTION_KEEP_ALIVE;
     }
 
     /**

--- a/src/Header/ContentDisposition.php
+++ b/src/Header/ContentDisposition.php
@@ -1,27 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class ContentDisposition implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-disposition') {
@@ -35,6 +35,7 @@ class ContentDisposition implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -43,16 +44,19 @@ class ContentDisposition implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Content-Disposition';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Content-Disposition: ' . $this->getFieldValue();

--- a/src/Header/ContentEncoding.php
+++ b/src/Header/ContentEncoding.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class ContentEncoding implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-encoding') {
@@ -34,6 +33,7 @@ class ContentEncoding implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -42,16 +42,19 @@ class ContentEncoding implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Content-Encoding';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Content-Encoding: ' . $this->getFieldValue();

--- a/src/Header/ContentLanguage.php
+++ b/src/Header/ContentLanguage.php
@@ -1,27 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.12
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class ContentLanguage implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-language') {
@@ -35,6 +35,7 @@ class ContentLanguage implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -43,16 +44,19 @@ class ContentLanguage implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Content-Language';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Content-Language: ' . $this->getFieldValue();

--- a/src/Header/ContentLength.php
+++ b/src/Header/ContentLength.php
@@ -1,27 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class ContentLength implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-length') {
@@ -35,6 +35,7 @@ class ContentLength implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if (null !== $value) {
@@ -43,16 +44,19 @@ class ContentLength implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Content-Length';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Content-Length: ' . $this->getFieldValue();

--- a/src/Header/ContentLocation.php
+++ b/src/Header/ContentLocation.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 /**

--- a/src/Header/ContentMD5.php
+++ b/src/Header/ContentMD5.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.15
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class ContentMD5 implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-md5') {
@@ -32,6 +31,7 @@ class ContentMD5 implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class ContentMD5 implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Content-MD5';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Content-MD5: ' . $this->getFieldValue();

--- a/src/Header/ContentRange.php
+++ b/src/Header/ContentRange.php
@@ -1,27 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.16
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class ContentRange implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-range') {
@@ -35,6 +35,7 @@ class ContentRange implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -43,16 +44,19 @@ class ContentRange implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Content-Range';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Content-Range: ' . $this->getFieldValue();

--- a/src/Header/ContentSecurityPolicy.php
+++ b/src/Header/ContentSecurityPolicy.php
@@ -1,12 +1,16 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function array_pad;
+use function array_walk;
+use function explode;
+use function implode;
+use function in_array;
+use function sprintf;
+use function str_replace;
+use function strcasecmp;
+use function trim;
 
 /**
  * Content Security Policy Level 3 Header
@@ -99,7 +103,8 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
             ));
         }
 
-        if ($name === 'block-all-mixed-content'
+        if (
+            $name === 'block-all-mixed-content'
             || $name === 'upgrade-insecure-requests'
         ) {
             if ($sources) {
@@ -140,11 +145,11 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
      */
     public static function fromString($headerLine)
     {
-        $header = new static();
-        $headerName = $header->getFieldName();
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        $header         = new static();
+        $headerName     = $header->getFieldName();
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
         // Ensure the proper header name
-        if (strcasecmp($name, $headerName) != 0) {
+        if (strcasecmp($name, $headerName) !== 0) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Invalid header line for %s string: "%s"',
                 $headerName,
@@ -156,7 +161,7 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
         foreach ($tokens as $token) {
             $token = trim($token);
             if ($token) {
-                list($directiveName, $directiveValue) = array_pad(explode(' ', $token, 2), 2, null);
+                [$directiveName, $directiveValue] = array_pad(explode(' ', $token, 2), 2, null);
                 if (! isset($header->directives[$directiveName])) {
                     $header->setDirective(
                         $directiveName,
@@ -202,6 +207,7 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
         return sprintf('%s: %s', $this->getFieldName(), $this->getFieldValue());
     }
 
+    /** @return string */
     public function toStringMultipleHeaders(array $headers)
     {
         $strings = [$this->toString()];

--- a/src/Header/ContentSecurityPolicyReportOnly.php
+++ b/src/Header/ContentSecurityPolicyReportOnly.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 /**

--- a/src/Header/ContentTransferEncoding.php
+++ b/src/Header/ContentTransferEncoding.php
@@ -1,27 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11 @todo find section
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class ContentTransferEncoding implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-transfer-encoding') {
@@ -35,6 +35,7 @@ class ContentTransferEncoding implements HeaderInterface
         return new static(strtolower($value));
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -43,16 +44,19 @@ class ContentTransferEncoding implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Content-Transfer-Encoding';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Content-Transfer-Encoding: ' . $this->getFieldValue();

--- a/src/Header/Date.php
+++ b/src/Header/Date.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 /**

--- a/src/Header/Etag.php
+++ b/src/Header/Etag.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Etag implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'etag') {
@@ -32,6 +31,7 @@ class Etag implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class Etag implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Etag';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Etag: ' . $this->getFieldValue();

--- a/src/Header/Exception/DomainException.php
+++ b/src/Header/Exception/DomainException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header\Exception;
 
 class DomainException extends \DomainException implements ExceptionInterface

--- a/src/Header/Exception/ExceptionInterface.php
+++ b/src/Header/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header\Exception;
 
 use Laminas\Http\Exception\ExceptionInterface as HttpException;

--- a/src/Header/Exception/InvalidArgumentException.php
+++ b/src/Header/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header\Exception;
 
 use Laminas\Http\Exception;

--- a/src/Header/Exception/RuntimeException.php
+++ b/src/Header/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header\Exception;
 
 use Laminas\Http\Exception;

--- a/src/Header/Expect.php
+++ b/src/Header/Expect.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Expect implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'expect') {
@@ -32,6 +31,7 @@ class Expect implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class Expect implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Expect';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Expect: ' . $this->getFieldValue();

--- a/src/Header/Expires.php
+++ b/src/Header/Expires.php
@@ -1,12 +1,10 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function date;
+
+use const DATE_W3C;
 
 /**
  * Expires Header
@@ -25,6 +23,10 @@ class Expires extends AbstractDate
         return 'Expires';
     }
 
+    /**
+     * @param int|string|DateTime $date
+     * @return static
+     */
     public function setDate($date)
     {
         if ($date === '0' || $date === 0) {

--- a/src/Header/FeaturePolicy.php
+++ b/src/Header/FeaturePolicy.php
@@ -1,12 +1,15 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function array_pad;
+use function array_walk;
+use function explode;
+use function implode;
+use function in_array;
+use function sprintf;
+use function strcasecmp;
+use function trim;
 
 /**
  * Feature Policy (based on Editor’s Draft, 28 November 2019)
@@ -18,9 +21,9 @@ class FeaturePolicy implements HeaderInterface
     /**
      * Valid directive names
      *
-     * @var string[]
-     *
      * @see https://github.com/w3c/webappsec-feature-policy/blob/master/features.md
+     *
+     * @var string[]
      */
     protected $validDirectiveNames = [
         // Standardized Features
@@ -120,9 +123,9 @@ class FeaturePolicy implements HeaderInterface
      */
     public static function fromString($headerLine)
     {
-        $header = new static();
-        $headerName = $header->getFieldName();
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        $header         = new static();
+        $headerName     = $header->getFieldName();
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
         // Ensure the proper header name
         if (strcasecmp($name, $headerName) !== 0) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -136,7 +139,7 @@ class FeaturePolicy implements HeaderInterface
         foreach ($tokens as $token) {
             $token = trim($token);
             if ($token) {
-                list($directiveName, $directiveValue) = array_pad(explode(' ', $token, 2), 2, null);
+                [$directiveName, $directiveValue] = array_pad(explode(' ', $token, 2), 2, null);
                 if (! isset($header->directives[$directiveName])) {
                     $header->setDirective(
                         $directiveName,

--- a/src/Header/From.php
+++ b/src/Header/From.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.22
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class From implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'from') {
@@ -32,6 +31,7 @@ class From implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class From implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'From';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'From: ' . $this->getFieldValue();

--- a/src/Header/GenericHeader.php
+++ b/src/Header/GenericHeader.php
@@ -1,26 +1,22 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function count;
+use function explode;
+use function is_string;
+use function ltrim;
+use function preg_match;
 
 /**
  * Content-Location Header
  */
 class GenericHeader implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $fieldName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $fieldValue;
 
     /**
@@ -31,7 +27,7 @@ class GenericHeader implements HeaderInterface
      */
     public static function fromString($headerLine)
     {
-        list($fieldName, $fieldValue) = GenericHeader::splitHeaderLine($headerLine);
+        [$fieldName, $fieldValue] = self::splitHeaderLine($headerLine);
 
         return new static($fieldName, $fieldValue);
     }
@@ -41,7 +37,7 @@ class GenericHeader implements HeaderInterface
      *
      * @param string $headerLine
      * @return string[] `name` in the first index and `value` in the second.
-     * @throws Exception\InvalidArgumentException If header does not match with the format ``name:value``
+     * @throws Exception\InvalidArgumentException If header does not match with the format ``name:value``.
      */
     public static function splitHeaderLine($headerLine)
     {

--- a/src/Header/GenericMultiHeader.php
+++ b/src/Header/GenericMultiHeader.php
@@ -1,18 +1,20 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function explode;
+use function implode;
+use function strpos;
 
 class GenericMultiHeader extends GenericHeader implements MultipleHeaderInterface
 {
+    /**
+     * @param string $headerLine
+     * @return static|static[]
+     */
     public static function fromString($headerLine)
     {
-        list($fieldName, $fieldValue) = GenericHeader::splitHeaderLine($headerLine);
+        [$fieldName, $fieldValue] = GenericHeader::splitHeaderLine($headerLine);
 
         if (strpos($fieldValue, ',')) {
             $headers = [];
@@ -21,14 +23,14 @@ class GenericMultiHeader extends GenericHeader implements MultipleHeaderInterfac
             }
             return $headers;
         } else {
-            $header = new static($fieldName, $fieldValue);
-            return $header;
+            return new static($fieldName, $fieldValue);
         }
     }
 
+    /** @return string */
     public function toStringMultipleHeaders(array $headers)
     {
-        $name  = $this->getFieldName();
+        $name   = $this->getFieldName();
         $values = [$this->getFieldValue()];
         foreach ($headers as $header) {
             if (! $header instanceof static) {

--- a/src/Header/HeaderInterface.php
+++ b/src/Header/HeaderInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 /**
@@ -16,10 +10,11 @@ interface HeaderInterface
     /**
      * Factory to generate a header object from a string
      *
+     * @see http://tools.ietf.org/html/rfc2616#section-4.2
+     *
      * @param string $headerLine
      * @return static
      * @throws Exception\InvalidArgumentException If the header does not match RFC 2616 definition.
-     * @see http://tools.ietf.org/html/rfc2616#section-4.2
      */
     public static function fromString($headerLine);
 

--- a/src/Header/HeaderValue.php
+++ b/src/Header/HeaderValue.php
@@ -1,12 +1,9 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function ord;
+use function strlen;
 
 final class HeaderValue
 {
@@ -27,6 +24,7 @@ final class HeaderValue
      * between visible characters.
      *
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @param string $value
      * @return string
      */
@@ -43,7 +41,8 @@ final class HeaderValue
             // 32-126, 128-254 === visible
             // 127 === DEL
             // 255 === null byte
-            if (($ascii < 32 && $ascii !== 9)
+            if (
+                ($ascii < 32 && $ascii !== 9)
                 || $ascii === 127
                 || $ascii > 254
             ) {
@@ -64,6 +63,7 @@ final class HeaderValue
      * between visible characters.
      *
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @param string $value
      * @return bool
      */
@@ -79,7 +79,8 @@ final class HeaderValue
             // 32-126, 128-254 === visible
             // 127 === DEL
             // 255 === null byte
-            if (($ascii < 32 && $ascii !== 9)
+            if (
+                ($ascii < 32 && $ascii !== 9)
                 || $ascii === 127
                 || $ascii > 254
             ) {
@@ -94,7 +95,7 @@ final class HeaderValue
      * Assert a header value is valid.
      *
      * @param string $value
-     * @throws Exception\RuntimeException for invalid values
+     * @throws Exception\RuntimeException For invalid values.
      * @return void
      */
     public static function assertValid($value)

--- a/src/Header/Host.php
+++ b/src/Header/Host.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Host implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'host') {
@@ -32,6 +31,7 @@ class Host implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class Host implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Host';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Host: ' . $this->getFieldValue();

--- a/src/Header/IfMatch.php
+++ b/src/Header/IfMatch.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class IfMatch implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'if-match') {
@@ -32,6 +31,7 @@ class IfMatch implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class IfMatch implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'If-Match';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'If-Match: ' . $this->getFieldValue();

--- a/src/Header/IfModifiedSince.php
+++ b/src/Header/IfModifiedSince.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 /**

--- a/src/Header/IfNoneMatch.php
+++ b/src/Header/IfNoneMatch.php
@@ -1,27 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class IfNoneMatch implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'if-none-match') {
@@ -35,6 +35,7 @@ class IfNoneMatch implements HeaderInterface
         return new static($value);
     }
 
+    /** @param string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -43,16 +44,19 @@ class IfNoneMatch implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'If-None-Match';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'If-None-Match: ' . $this->getFieldValue();

--- a/src/Header/IfRange.php
+++ b/src/Header/IfRange.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.27
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class IfRange implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'if-range') {
@@ -32,6 +31,7 @@ class IfRange implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class IfRange implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'If-Range';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'If-Range: ' . $this->getFieldValue();

--- a/src/Header/IfUnmodifiedSince.php
+++ b/src/Header/IfUnmodifiedSince.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 /**

--- a/src/Header/KeepAlive.php
+++ b/src/Header/KeepAlive.php
@@ -1,12 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function strtolower;
 
 /**
  * @throws Exception\InvalidArgumentException
@@ -14,14 +10,16 @@ namespace Laminas\Http\Header;
  */
 class KeepAlive implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'keep-alive') {
@@ -32,6 +30,7 @@ class KeepAlive implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +39,19 @@ class KeepAlive implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Keep-Alive';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Keep-Alive: ' . $this->getFieldValue();

--- a/src/Header/LastModified.php
+++ b/src/Header/LastModified.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 /**

--- a/src/Header/Location.php
+++ b/src/Header/Location.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 /**

--- a/src/Header/MaxForwards.php
+++ b/src/Header/MaxForwards.php
@@ -1,27 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.31
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class MaxForwards implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'max-forwards') {
@@ -35,6 +35,7 @@ class MaxForwards implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -43,16 +44,19 @@ class MaxForwards implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Max-Forwards';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Max-Forwards: ' . $this->getFieldValue();

--- a/src/Header/MultipleHeaderInterface.php
+++ b/src/Header/MultipleHeaderInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 interface MultipleHeaderInterface extends HeaderInterface

--- a/src/Header/Origin.php
+++ b/src/Header/Origin.php
@@ -1,29 +1,29 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 use Laminas\Uri\UriFactory;
 
+use function explode;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://tools.ietf.org/id/draft-abarth-origin-03.html#rfc.section.2
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Origin implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value = '';
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = explode(': ', $headerLine, 2);
+        [$name, $value] = explode(': ', $headerLine, 2);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'origin') {
@@ -49,16 +49,19 @@ class Origin implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Origin';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Origin: ' . $this->getFieldValue();

--- a/src/Header/Pragma.php
+++ b/src/Header/Pragma.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Pragma implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'pragma') {
@@ -32,6 +31,7 @@ class Pragma implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class Pragma implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Pragma';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Pragma: ' . $this->getFieldValue();

--- a/src/Header/ProxyAuthenticate.php
+++ b/src/Header/ProxyAuthenticate.php
@@ -1,27 +1,28 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function implode;
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.33
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class ProxyAuthenticate implements MultipleHeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'proxy-authenticate') {
@@ -35,6 +36,7 @@ class ProxyAuthenticate implements MultipleHeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -43,21 +45,25 @@ class ProxyAuthenticate implements MultipleHeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Proxy-Authenticate';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Proxy-Authenticate: ' . $this->getFieldValue();
     }
 
+    /** @return string */
     public function toStringMultipleHeaders(array $headers)
     {
         $strings = [$this->toString()];

--- a/src/Header/ProxyAuthorization.php
+++ b/src/Header/ProxyAuthorization.php
@@ -1,27 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.34
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class ProxyAuthorization implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'proxy-authorization') {
@@ -35,6 +35,7 @@ class ProxyAuthorization implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -43,16 +44,19 @@ class ProxyAuthorization implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Proxy-Authorization';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Proxy-Authorization: ' . $this->getFieldValue();

--- a/src/Header/Range.php
+++ b/src/Header/Range.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35.2
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Range implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'range') {
@@ -32,6 +31,7 @@ class Range implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class Range implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Range';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Range: ' . $this->getFieldValue();

--- a/src/Header/Referer.php
+++ b/src/Header/Referer.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 use Laminas\Uri\Http as HttpUri;

--- a/src/Header/Refresh.php
+++ b/src/Header/Refresh.php
@@ -1,12 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function strtolower;
 
 /**
  * @throws Exception\InvalidArgumentException
@@ -14,14 +10,16 @@ namespace Laminas\Http\Header;
  */
 class Refresh implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'refresh') {
@@ -32,6 +30,7 @@ class Refresh implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +39,19 @@ class Refresh implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Refresh';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Refresh: ' . $this->getFieldValue();

--- a/src/Header/RetryAfter.php
+++ b/src/Header/RetryAfter.php
@@ -1,12 +1,9 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
+
+use function is_numeric;
+use function strtolower;
 
 /**
  * Retry-After HTTP Header
@@ -34,7 +31,7 @@ class RetryAfter extends AbstractDate
     {
         $dateHeader = new static();
 
-        list($name, $date) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $date] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== strtolower($dateHeader->getFieldName())) {
@@ -91,7 +88,7 @@ class RetryAfter extends AbstractDate
      */
     public function getFieldValue()
     {
-        return ($this->date === null) ? $this->deltaSeconds : $this->getDate();
+        return $this->date === null ? $this->deltaSeconds : $this->getDate();
     }
 
     /**

--- a/src/Header/Server.php
+++ b/src/Header/Server.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.38
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Server implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'server') {
@@ -32,6 +31,7 @@ class Server implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class Server implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Server';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Server: ' . $this->getFieldValue();

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -1,25 +1,42 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
 use DateTime;
+use Laminas\Uri\Uri;
 use Laminas\Uri\UriFactory;
 
 use function array_key_exists;
+use function array_pop;
+use function count;
 use function gettype;
+use function gmdate;
+use function is_int;
+use function is_numeric;
 use function is_scalar;
+use function is_string;
+use function max;
+use function preg_match;
+use function preg_quote;
+use function preg_split;
+use function sprintf;
+use function str_replace;
+use function strpos;
+use function strrpos;
 use function strtolower;
+use function strtotime;
+use function time;
+use function urldecode;
+use function urlencode;
+
+use const PHP_INT_MAX;
+use const PHP_INT_SIZE;
 
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.ietf.org/rfc/rfc2109.txt
  * @see http://www.w3.org/Protocols/rfc2109/rfc2109
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class SetCookie implements MultipleHeaderInterface
 {
@@ -27,27 +44,27 @@ class SetCookie implements MultipleHeaderInterface
      * Cookie will not be sent for any cross-domain requests whatsoever.
      * Even if the user simply navigates to the target site with a regular link, the cookie will not be sent.
      */
-    const SAME_SITE_STRICT = 'Strict';
+    public const SAME_SITE_STRICT = 'Strict';
 
     /**
      * Cookie will not be passed for any cross-domain requests unless it's a regular link that navigates user
      * to the target site.
      * Other requests methods (such as POST and PUT) and XHR requests will not contain this cookie.
      */
-    const SAME_SITE_LAX = 'Lax';
+    public const SAME_SITE_LAX = 'Lax';
 
     /**
      * Cookie will be sent with same-site and cross-site requests.
      */
-    const SAME_SITE_NONE = 'None';
+    public const SAME_SITE_NONE = 'None';
 
     /**
      * @internal
      */
-    const SAME_SITE_ALLOWED_VALUES = [
+    public const SAME_SITE_ALLOWED_VALUES = [
         'strict' => self::SAME_SITE_STRICT,
-        'lax' => self::SAME_SITE_LAX,
-        'none' => self::SAME_SITE_NONE,
+        'lax'    => self::SAME_SITE_LAX,
+        'none'   => self::SAME_SITE_NONE,
     ];
 
     /**
@@ -113,25 +130,19 @@ class SetCookie implements MultipleHeaderInterface
      */
     protected $quoteFieldValue = false;
 
-    /**
-     * @var bool|null
-     */
+    /** @var bool|null */
     protected $httponly;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     protected $sameSite;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $encodeValue = true;
 
     /**
      * @static
      * @throws Exception\InvalidArgumentException
-     * @param  $headerLine
+     * @param  string $headerLine
      * @param  bool $bypassHeaderFieldName
      * @return array|SetCookie
      */
@@ -140,18 +151,18 @@ class SetCookie implements MultipleHeaderInterface
         static $setCookieProcessor = null;
 
         if ($setCookieProcessor === null) {
-            $setCookieClass = get_called_class();
+            $setCookieClass     = static::class;
             $setCookieProcessor = function ($headerLine) use ($setCookieClass) {
                 /** @var SetCookie $header */
-                $header = new $setCookieClass();
+                $header        = new $setCookieClass();
                 $keyValuePairs = preg_split('#;\s*#', $headerLine);
 
                 foreach ($keyValuePairs as $keyValue) {
                     if (preg_match('#^(?P<headerKey>[^=]+)=\s*("?)(?P<headerValue>[^"]*)\2#', $keyValue, $matches)) {
-                        $headerKey  = $matches['headerKey'];
+                        $headerKey   = $matches['headerKey'];
                         $headerValue = $matches['headerValue'];
                     } else {
-                        $headerKey = $keyValue;
+                        $headerKey   = $keyValue;
                         $headerValue = null;
                     }
 
@@ -202,11 +213,11 @@ class SetCookie implements MultipleHeaderInterface
             };
         }
 
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
         HeaderValue::assertValid($value);
 
         // some sites return set-cookie::value, this is to get rid of the second :
-        $name = strtolower($name) == 'set-cookie:' ? 'set-cookie' : $name;
+        $name = strtolower($name) === 'set-cookie:' ? 'set-cookie' : $name;
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'set-cookie') {
@@ -230,7 +241,6 @@ class SetCookie implements MultipleHeaderInterface
      * Cookie object constructor
      *
      * @todo Add validation of each one of the parameters (legal domain, etc.)
-     *
      * @param string|null              $name
      * @param string|null              $value
      * @param int|string|DateTime|null $expires
@@ -298,7 +308,8 @@ class SetCookie implements MultipleHeaderInterface
      */
     public function getFieldValue()
     {
-        if ($this->getName() == '') {
+        $name = $this->getName();
+        if ($name === '' || $name === null) {
             return '';
         }
 
@@ -307,7 +318,7 @@ class SetCookie implements MultipleHeaderInterface
             $value = '"' . $value . '"';
         }
 
-        $fieldValue = $this->getName() . '=' . $value;
+        $fieldValue = $name . '=' . $value;
 
         $version = $this->getVersion();
         if ($version !== null) {
@@ -606,7 +617,7 @@ class SetCookie implements MultipleHeaderInterface
      */
     public function isSessionCookie()
     {
-        return ($this->expires === null);
+        return $this->expires === null;
     }
 
     /**
@@ -674,7 +685,7 @@ class SetCookie implements MultipleHeaderInterface
     /**
      * Checks whether the cookie should be sent or not in a specific scenario
      *
-     * @param string|\Laminas\Uri\Uri $uri URI to check against (secure, domain, path)
+     * @param string|Uri $uri URI to check against (secure, domain, path)
      * @param bool $matchSessionCookies Whether to send session cookies
      * @param int|null $now Override the current time when checking for expiry time
      * @return bool
@@ -687,12 +698,12 @@ class SetCookie implements MultipleHeaderInterface
         }
 
         // Make sure we have a valid Laminas_Uri_Http object
-        if (! ($uri->isValid() && ($uri->getScheme() == 'http' || $uri->getScheme() == 'https'))) {
+        if (! ($uri->isValid() && ($uri->getScheme() === 'http' || $uri->getScheme() === 'https'))) {
             throw new Exception\InvalidArgumentException('Passed URI is not a valid HTTP or HTTPS URI');
         }
 
         // Check that the cookie is secure (if required) and not expired
-        if ($this->secure && $uri->getScheme() != 'https') {
+        if ($this->secure && $uri->getScheme() !== 'https') {
             return false;
         }
         if ($this->isExpired($now)) {
@@ -728,9 +739,9 @@ class SetCookie implements MultipleHeaderInterface
     public static function matchCookieDomain($cookieDomain, $host)
     {
         $cookieDomain = strtolower($cookieDomain);
-        $host = strtolower($host);
+        $host         = strtolower($host);
         // Check for either exact match or suffix match
-        return $cookieDomain == $host
+        return $cookieDomain === $host
             || preg_match('/' . preg_quote($cookieDomain) . '$/', $host);
     }
 
@@ -745,7 +756,7 @@ class SetCookie implements MultipleHeaderInterface
      */
     public static function matchCookiePath($cookiePath, $path)
     {
-        return (strpos($path, $cookiePath) === 0);
+        return strpos($path, $cookiePath) === 0;
     }
 
     /**
@@ -764,7 +775,7 @@ class SetCookie implements MultipleHeaderInterface
     public function toStringMultipleHeaders(array $headers)
     {
         $headerLine = $this->toString();
-        /* @var $header SetCookie */
+        /** @var SetCookie $header */
         foreach ($headers as $header) {
             if (! $header instanceof SetCookie) {
                 throw new Exception\RuntimeException(

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -169,10 +169,10 @@ class SetCookie implements MultipleHeaderInterface
                     // First K=V pair is always the cookie name and value
                     if ($header->getName() === null) {
                         $header->setName($headerKey);
-                        $header->setValue(urldecode($headerValue));
+                        $header->setValue(urldecode($headerValue ?? ''));
 
                         // set no encode value if raw and encoded values are the same
-                        if (urldecode($headerValue) === $headerValue) {
+                        if (urldecode($headerValue ?? '') === $headerValue) {
                             $header->setEncodeValue(false);
                         }
                         continue;
@@ -313,7 +313,7 @@ class SetCookie implements MultipleHeaderInterface
             return '';
         }
 
-        $value = $this->encodeValue ? urlencode($this->getValue()) : $this->getValue();
+        $value = $this->encodeValue ? urlencode($this->getValue() ?? '') : $this->getValue();
         if ($this->hasQuoteFieldValue()) {
             $value = '"' . $value . '"';
         }

--- a/src/Header/TE.php
+++ b/src/Header/TE.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.39
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class TE implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'te') {
@@ -32,6 +31,7 @@ class TE implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class TE implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'TE';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'TE: ' . $this->getFieldValue();

--- a/src/Header/Trailer.php
+++ b/src/Header/Trailer.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.40
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Trailer implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'trailer') {
@@ -32,6 +31,7 @@ class Trailer implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class Trailer implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Trailer';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Trailer: ' . $this->getFieldValue();

--- a/src/Header/TransferEncoding.php
+++ b/src/Header/TransferEncoding.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.41
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class TransferEncoding implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'transfer-encoding') {
@@ -34,6 +33,7 @@ class TransferEncoding implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -42,16 +42,19 @@ class TransferEncoding implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Transfer-Encoding';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Transfer-Encoding: ' . $this->getFieldValue();

--- a/src/Header/Upgrade.php
+++ b/src/Header/Upgrade.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.42
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Upgrade implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'upgrade') {
@@ -32,6 +31,7 @@ class Upgrade implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class Upgrade implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Upgrade';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Upgrade: ' . $this->getFieldValue();

--- a/src/Header/UserAgent.php
+++ b/src/Header/UserAgent.php
@@ -1,27 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function str_replace;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class UserAgent implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (str_replace(['_', ' ', '.'], '-', strtolower($name)) !== 'user-agent') {
@@ -32,6 +32,7 @@ class UserAgent implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +41,19 @@ class UserAgent implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'User-Agent';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'User-Agent: ' . $this->getFieldValue();

--- a/src/Header/Vary.php
+++ b/src/Header/Vary.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.44
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Vary implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'vary') {
@@ -32,6 +31,7 @@ class Vary implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class Vary implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Vary';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Vary: ' . $this->getFieldValue();

--- a/src/Header/Via.php
+++ b/src/Header/Via.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.45
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Via implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'via') {
@@ -32,6 +31,7 @@ class Via implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class Via implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Via';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Via: ' . $this->getFieldValue();

--- a/src/Header/WWWAuthenticate.php
+++ b/src/Header/WWWAuthenticate.php
@@ -1,27 +1,28 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function implode;
+use function sprintf;
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.47
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class WWWAuthenticate implements MultipleHeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'www-authenticate') {
@@ -35,6 +36,7 @@ class WWWAuthenticate implements MultipleHeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -43,21 +45,25 @@ class WWWAuthenticate implements MultipleHeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'WWW-Authenticate';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'WWW-Authenticate: ' . $this->getFieldValue();
     }
 
+    /** @return string */
     public function toStringMultipleHeaders(array $headers)
     {
         $strings = [$this->toString()];

--- a/src/Header/Warning.php
+++ b/src/Header/Warning.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Header;
 
+use function strtolower;
+
 /**
- * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.46
+ *
+ * @throws Exception\InvalidArgumentException
  */
 class Warning implements HeaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
+    /**
+     * @param string $headerLine
+     * @return static
+     */
     public static function fromString($headerLine)
     {
-        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        [$name, $value] = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'warning') {
@@ -32,6 +31,7 @@ class Warning implements HeaderInterface
         return new static($value);
     }
 
+    /** @param null|string $value */
     public function __construct($value = null)
     {
         if ($value !== null) {
@@ -40,16 +40,19 @@ class Warning implements HeaderInterface
         }
     }
 
+    /** @return string */
     public function getFieldName()
     {
         return 'Warning';
     }
 
+    /** @return string */
     public function getFieldValue()
     {
         return (string) $this->value;
     }
 
+    /** @return string */
     public function toString()
     {
         return 'Warning: ' . $this->getFieldValue();

--- a/src/HeaderLoader.php
+++ b/src/HeaderLoader.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http;
 
 use Laminas\Loader\PluginClassLoader;
@@ -15,9 +9,7 @@ use Laminas\Loader\PluginClassLoader;
  */
 class HeaderLoader extends PluginClassLoader
 {
-    /**
-     * @var array Pre-aliased Header plugins
-     */
+    /** @var array Pre-aliased Header plugins */
     protected $plugins = [
         'accept'                  => Header\Accept::class,
         'acceptcharset'           => Header\AcceptCharset::class,

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -9,6 +9,8 @@ use Laminas\Http\Header\Exception;
 use Laminas\Http\Header\GenericHeader;
 use Laminas\Http\Header\MultipleHeaderInterface;
 use Laminas\Loader\PluginClassLocator;
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use ReturnTypeWillChange;
 use Traversable;
 
 use function array_keys;
@@ -338,6 +340,7 @@ class Headers implements Countable, Iterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         next($this->headers);
@@ -348,6 +351,7 @@ class Headers implements Countable, Iterator
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->headers);
@@ -358,6 +362,7 @@ class Headers implements Countable, Iterator
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return current($this->headers) !== false;
@@ -368,6 +373,7 @@ class Headers implements Countable, Iterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->headers);
@@ -378,6 +384,7 @@ class Headers implements Countable, Iterator
      *
      * @return array|Header\HeaderInterface
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $current = current($this->headers);
@@ -393,6 +400,7 @@ class Headers implements Countable, Iterator
      *
      * @return int count of currently known headers
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->headers);

--- a/src/PhpEnvironment/RemoteAddress.php
+++ b/src/PhpEnvironment/RemoteAddress.php
@@ -1,12 +1,15 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\PhpEnvironment;
+
+use function array_diff;
+use function array_map;
+use function array_pop;
+use function explode;
+use function in_array;
+use function str_replace;
+use function strpos;
+use function strtoupper;
 
 /**
  * Functionality for determining client IP address.
@@ -112,11 +115,13 @@ class RemoteAddress
      * Attempt to get the IP address for a proxied client
      *
      * @see http://tools.ietf.org/html/draft-ietf-appsawg-http-forwarded-10#section-5.2
+     *
      * @return false|string
      */
     protected function getIpAddressFromProxy()
     {
-        if (! $this->useProxy
+        if (
+            ! $this->useProxy
             || (isset($_SERVER['REMOTE_ADDR']) && ! in_array($_SERVER['REMOTE_ADDR'], $this->trustedProxies))
         ) {
             return false;
@@ -144,8 +149,7 @@ class RemoteAddress
         // not know if it is a proxy server, or a client. As such, we treat it
         // as the originating IP.
         // @see http://en.wikipedia.org/wiki/X-Forwarded-For
-        $ip = array_pop($ips);
-        return $ip;
+        return array_pop($ips);
     }
 
     /**

--- a/src/PhpEnvironment/Request.php
+++ b/src/PhpEnvironment/Request.php
@@ -234,7 +234,7 @@ class Request extends HttpRequest
         $headers = [];
 
         foreach ($server as $key => $value) {
-            if ($value || (! is_array($value) && strlen($value))) {
+            if ($value || (! is_array($value) && strlen($value ?? ''))) {
                 if (strpos($key, 'HTTP_') === 0) {
                     if (strpos($key, 'HTTP_COOKIE') === 0) {
                         // Cookies are handled using the $_COOKIE superglobal
@@ -518,7 +518,7 @@ class Request extends HttpRequest
             }
 
             $baseUrl  = '/';
-            $basename = basename($filename);
+            $basename = basename($filename ?? '');
             if ($basename) {
                 $path     = $phpSelf ? trim($phpSelf, '/') : '';
                 $basePos  = strpos($path, $basename) ?: 0;

--- a/src/PhpEnvironment/Request.php
+++ b/src/PhpEnvironment/Request.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\PhpEnvironment;
 
 use Laminas\Http\Header\Cookie;
@@ -14,6 +8,28 @@ use Laminas\Stdlib\Parameters;
 use Laminas\Stdlib\ParametersInterface;
 use Laminas\Uri\Http as HttpUri;
 use Laminas\Validator\Hostname as HostnameValidator;
+
+use function basename;
+use function dirname;
+use function file_get_contents;
+use function function_exists;
+use function is_array;
+use function is_string;
+use function preg_match;
+use function preg_replace;
+use function rtrim;
+use function str_replace;
+use function strlen;
+use function strpos;
+use function strrpos;
+use function strtolower;
+use function strtr;
+use function substr;
+use function trim;
+use function ucfirst;
+use function ucwords;
+
+use const PHP_SAPI;
 
 /**
  * HTTP Request for current PHP environment
@@ -107,7 +123,7 @@ class Request extends HttpRequest
      *
      * Instantiate and set cookies.
      *
-     * @param $cookie
+     * @param string|array<string, string> $cookie
      * @return $this
      */
     public function setCookies($cookie)
@@ -196,7 +212,6 @@ class Request extends HttpRequest
      * Provide an alternate Parameter Container implementation for server parameters in this object,
      * (this is NOT the primary API for value setting, for that see getServer())
      *
-     * @param  ParametersInterface $server
      * @return $this
      */
     public function setServer(ParametersInterface $server)
@@ -229,7 +244,7 @@ class Request extends HttpRequest
                     $headers[strtr(ucwords(strtolower(strtr(substr($key, 5), '_', ' '))), ' ', '-')] = $value;
                 } elseif (strpos($key, 'CONTENT_') === 0) {
                     $name = substr($key, 8); // Remove "Content-"
-                    $headers['Content-' . (($name == 'MD5') ? $name : ucfirst(strtolower($name)))] = $value;
+                    $headers['Content-' . ($name === 'MD5' ? $name : ucfirst(strtolower($name)))] = $value;
                 }
             }
         }
@@ -242,7 +257,8 @@ class Request extends HttpRequest
         }
 
         // set HTTP version
-        if (isset($this->serverParams['SERVER_PROTOCOL'])
+        if (
+            isset($this->serverParams['SERVER_PROTOCOL'])
             && strpos($this->serverParams['SERVER_PROTOCOL'], self::VERSION_10) !== false
         ) {
             $this->setVersion(self::VERSION_10);
@@ -252,9 +268,10 @@ class Request extends HttpRequest
         $uri = new HttpUri();
 
         // URI scheme
-        if ((! empty($this->serverParams['HTTPS']) && strtolower($this->serverParams['HTTPS']) !== 'off')
+        if (
+            (! empty($this->serverParams['HTTPS']) && strtolower($this->serverParams['HTTPS']) !== 'off')
             || (! empty($this->serverParams['HTTP_X_FORWARDED_PROTO'])
-                 && $this->serverParams['HTTP_X_FORWARDED_PROTO'] == 'https')
+                 && $this->serverParams['HTTP_X_FORWARDED_PROTO'] === 'https')
         ) {
             $scheme = 'https';
         } else {
@@ -299,7 +316,7 @@ class Request extends HttpRequest
             // Reported at least for Safari on Windows
             if (isset($this->serverParams['SERVER_ADDR']) && preg_match('/^\[[0-9a-fA-F\:]+\]$/', $host)) {
                 $host = '[' . $this->serverParams['SERVER_ADDR'] . ']';
-                if ($port . ']' == substr($host, strrpos($host, ':') + 1)) {
+                if ($port . ']' === substr($host, strrpos($host, ':') + 1)) {
                     // The last digit of the IPv6-Address has been taken as port
                     // Unset the port so the default port can be used
                     $port = null;
@@ -330,10 +347,11 @@ class Request extends HttpRequest
     /**
      * Return the parameter container responsible for server parameters or a single parameter value.
      *
+     * @see http://www.faqs.org/rfcs/rfc3875.html
+     *
      * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
      * @param mixed|null            $default         Default value to use when the parameter is missing.
-     * @see http://www.faqs.org/rfcs/rfc3875.html
-     * @return \Laminas\Stdlib\ParametersInterface|mixed
+     * @return ParametersInterface|mixed
      */
     public function getServer($name = null, $default = null)
     {
@@ -352,7 +370,6 @@ class Request extends HttpRequest
      * Provide an alternate Parameter Container implementation for env parameters in this object,
      * (this is NOT the primary API for value setting, for that see env())
      *
-     * @param  ParametersInterface $env
      * @return $this
      */
     public function setEnv(ParametersInterface $env)
@@ -366,7 +383,7 @@ class Request extends HttpRequest
      *
      * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
      * @param mixed|null            $default         Default value to use when the parameter is missing.
-     * @return \Laminas\Stdlib\ParametersInterface|mixed
+     * @return ParametersInterface|mixed
      */
     public function getEnv($name = null, $default = null)
     {
@@ -440,7 +457,7 @@ class Request extends HttpRequest
         // (double slash problem).
         $iisUrlRewritten = $server->get('IIS_WasUrlRewritten');
         $unencodedUrl    = $server->get('UNENCODED_URL', '');
-        if ('1' == $iisUrlRewritten && '' !== $unencodedUrl) {
+        if ('1' === $iisUrlRewritten && '' !== $unencodedUrl) {
             return $unencodedUrl;
         }
 
@@ -503,7 +520,7 @@ class Request extends HttpRequest
             $baseUrl  = '/';
             $basename = basename($filename);
             if ($basename) {
-                $path     = ($phpSelf ? trim($phpSelf, '/') : '');
+                $path     = $phpSelf ? trim($phpSelf, '/') : '';
                 $basePos  = strpos($path, $basename) ?: 0;
                 $baseUrl .= substr($path, 0, $basePos) . $basename;
             }
@@ -544,7 +561,8 @@ class Request extends HttpRequest
         // If using mod_rewrite or ISAPI_Rewrite strip the script filename
         // out of the base path. $pos !== 0 makes sure it is not matching a
         // value from PATH_INFO or QUERY_STRING.
-        if (strlen($requestUri) >= strlen($baseUrl)
+        if (
+            strlen($requestUri) >= strlen($baseUrl)
             && (false !== ($pos = strpos($requestUri, $baseUrl)) && $pos !== 0)
         ) {
             $baseUrl = substr($requestUri, 0, $pos + strlen($baseUrl));
@@ -562,7 +580,7 @@ class Request extends HttpRequest
      */
     protected function detectBasePath()
     {
-        $baseUrl  = $this->getBaseUrl();
+        $baseUrl = $this->getBaseUrl();
 
         // Empty base url detected
         if ($baseUrl === '') {

--- a/src/PhpEnvironment/Response.php
+++ b/src/PhpEnvironment/Response.php
@@ -1,15 +1,14 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\PhpEnvironment;
 
+use Laminas\Http\Header\HeaderInterface;
 use Laminas\Http\Header\MultipleHeaderInterface;
 use Laminas\Http\Response as HttpResponse;
+
+use function call_user_func;
+use function header;
+use function headers_sent;
 
 /**
  * HTTP Response for current PHP environment
@@ -24,21 +23,18 @@ class Response extends HttpResponse
      */
     protected $version;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $contentSent = false;
 
-    /**
-     * @var null|callable
-     */
+    /** @var null|callable */
     private $headersSentHandler;
 
     /**
      * Return the HTTP version for this response
      *
-     * @return string
      * @see \Laminas\Http\AbstractMessage::getVersion()
+     *
+     * @return string
      */
     public function getVersion()
     {
@@ -56,7 +52,7 @@ class Response extends HttpResponse
      */
     protected function detectVersion()
     {
-        if (isset($_SERVER['SERVER_PROTOCOL']) && $_SERVER['SERVER_PROTOCOL'] == 'HTTP/1.1') {
+        if (isset($_SERVER['SERVER_PROTOCOL']) && $_SERVER['SERVER_PROTOCOL'] === 'HTTP/1.1') {
             return self::VERSION_11;
         }
 
@@ -102,10 +98,10 @@ class Response extends HttpResponse
             return $this;
         }
 
-        $status  = $this->renderStatusLine();
+        $status = $this->renderStatusLine();
         header($status);
 
-        /** @var \Laminas\Http\Header\HeaderInterface $header */
+        /** @var HeaderInterface $header */
         foreach ($this->getHeaders() as $header) {
             if ($header instanceof MultipleHeaderInterface) {
                 header($header->toString(), false);

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,16 +1,30 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http;
 
-use Laminas\Http\Exception\RuntimeException;
 use Laminas\Stdlib\ErrorHandler;
 use Laminas\Stdlib\ResponseInterface;
+
+use function array_shift;
+use function count;
+use function explode;
+use function function_exists;
+use function gettype;
+use function gzinflate;
+use function gzuncompress;
+use function hexdec;
+use function implode;
+use function is_array;
+use function is_float;
+use function is_numeric;
+use function is_scalar;
+use function preg_match;
+use function sprintf;
+use function strlen;
+use function strtolower;
+use function substr;
+use function trim;
+use function unpack;
 
 /**
  * HTTP Response
@@ -20,88 +34,87 @@ use Laminas\Stdlib\ResponseInterface;
 class Response extends AbstractMessage implements ResponseInterface
 {
     /**#@+
+     *
      * @const int Status codes
      */
-    const STATUS_CODE_CUSTOM = 0;
-    const STATUS_CODE_100 = 100;
-    const STATUS_CODE_101 = 101;
-    const STATUS_CODE_102 = 102;
-    const STATUS_CODE_200 = 200;
-    const STATUS_CODE_201 = 201;
-    const STATUS_CODE_202 = 202;
-    const STATUS_CODE_203 = 203;
-    const STATUS_CODE_204 = 204;
-    const STATUS_CODE_205 = 205;
-    const STATUS_CODE_206 = 206;
-    const STATUS_CODE_207 = 207;
-    const STATUS_CODE_208 = 208;
-    const STATUS_CODE_226 = 226;
-    const STATUS_CODE_300 = 300;
-    const STATUS_CODE_301 = 301;
-    const STATUS_CODE_302 = 302;
-    const STATUS_CODE_303 = 303;
-    const STATUS_CODE_304 = 304;
-    const STATUS_CODE_305 = 305;
-    const STATUS_CODE_306 = 306;
-    const STATUS_CODE_307 = 307;
-    const STATUS_CODE_308 = 308;
-    const STATUS_CODE_400 = 400;
-    const STATUS_CODE_401 = 401;
-    const STATUS_CODE_402 = 402;
-    const STATUS_CODE_403 = 403;
-    const STATUS_CODE_404 = 404;
-    const STATUS_CODE_405 = 405;
-    const STATUS_CODE_406 = 406;
-    const STATUS_CODE_407 = 407;
-    const STATUS_CODE_408 = 408;
-    const STATUS_CODE_409 = 409;
-    const STATUS_CODE_410 = 410;
-    const STATUS_CODE_411 = 411;
-    const STATUS_CODE_412 = 412;
-    const STATUS_CODE_413 = 413;
-    const STATUS_CODE_414 = 414;
-    const STATUS_CODE_415 = 415;
-    const STATUS_CODE_416 = 416;
-    const STATUS_CODE_417 = 417;
-    const STATUS_CODE_418 = 418;
-    const STATUS_CODE_422 = 422;
-    const STATUS_CODE_423 = 423;
-    const STATUS_CODE_424 = 424;
-    const STATUS_CODE_425 = 425;
-    const STATUS_CODE_426 = 426;
-    const STATUS_CODE_428 = 428;
-    const STATUS_CODE_429 = 429;
-    const STATUS_CODE_431 = 431;
-    const STATUS_CODE_451 = 451;
-    const STATUS_CODE_444 = 444;
-    const STATUS_CODE_499 = 499;
-    const STATUS_CODE_500 = 500;
-    const STATUS_CODE_501 = 501;
-    const STATUS_CODE_502 = 502;
-    const STATUS_CODE_503 = 503;
-    const STATUS_CODE_504 = 504;
-    const STATUS_CODE_505 = 505;
-    const STATUS_CODE_506 = 506;
-    const STATUS_CODE_507 = 507;
-    const STATUS_CODE_508 = 508;
-    const STATUS_CODE_510 = 510;
-    const STATUS_CODE_511 = 511;
-    const STATUS_CODE_599 = 599;
+    public const STATUS_CODE_CUSTOM = 0;
+    public const STATUS_CODE_100    = 100;
+    public const STATUS_CODE_101    = 101;
+    public const STATUS_CODE_102    = 102;
+    public const STATUS_CODE_200    = 200;
+    public const STATUS_CODE_201    = 201;
+    public const STATUS_CODE_202    = 202;
+    public const STATUS_CODE_203    = 203;
+    public const STATUS_CODE_204    = 204;
+    public const STATUS_CODE_205    = 205;
+    public const STATUS_CODE_206    = 206;
+    public const STATUS_CODE_207    = 207;
+    public const STATUS_CODE_208    = 208;
+    public const STATUS_CODE_226    = 226;
+    public const STATUS_CODE_300    = 300;
+    public const STATUS_CODE_301    = 301;
+    public const STATUS_CODE_302    = 302;
+    public const STATUS_CODE_303    = 303;
+    public const STATUS_CODE_304    = 304;
+    public const STATUS_CODE_305    = 305;
+    public const STATUS_CODE_306    = 306;
+    public const STATUS_CODE_307    = 307;
+    public const STATUS_CODE_308    = 308;
+    public const STATUS_CODE_400    = 400;
+    public const STATUS_CODE_401    = 401;
+    public const STATUS_CODE_402    = 402;
+    public const STATUS_CODE_403    = 403;
+    public const STATUS_CODE_404    = 404;
+    public const STATUS_CODE_405    = 405;
+    public const STATUS_CODE_406    = 406;
+    public const STATUS_CODE_407    = 407;
+    public const STATUS_CODE_408    = 408;
+    public const STATUS_CODE_409    = 409;
+    public const STATUS_CODE_410    = 410;
+    public const STATUS_CODE_411    = 411;
+    public const STATUS_CODE_412    = 412;
+    public const STATUS_CODE_413    = 413;
+    public const STATUS_CODE_414    = 414;
+    public const STATUS_CODE_415    = 415;
+    public const STATUS_CODE_416    = 416;
+    public const STATUS_CODE_417    = 417;
+    public const STATUS_CODE_418    = 418;
+    public const STATUS_CODE_422    = 422;
+    public const STATUS_CODE_423    = 423;
+    public const STATUS_CODE_424    = 424;
+    public const STATUS_CODE_425    = 425;
+    public const STATUS_CODE_426    = 426;
+    public const STATUS_CODE_428    = 428;
+    public const STATUS_CODE_429    = 429;
+    public const STATUS_CODE_431    = 431;
+    public const STATUS_CODE_451    = 451;
+    public const STATUS_CODE_444    = 444;
+    public const STATUS_CODE_499    = 499;
+    public const STATUS_CODE_500    = 500;
+    public const STATUS_CODE_501    = 501;
+    public const STATUS_CODE_502    = 502;
+    public const STATUS_CODE_503    = 503;
+    public const STATUS_CODE_504    = 504;
+    public const STATUS_CODE_505    = 505;
+    public const STATUS_CODE_506    = 506;
+    public const STATUS_CODE_507    = 507;
+    public const STATUS_CODE_508    = 508;
+    public const STATUS_CODE_510    = 510;
+    public const STATUS_CODE_511    = 511;
+    public const STATUS_CODE_599    = 599;
     /**#@-*/
 
     /**
      * @internal
      */
-    const MIN_STATUS_CODE_VALUE = 100;
+    public const MIN_STATUS_CODE_VALUE = 100;
 
     /**
      * @internal
      */
-    const MAX_STATUS_CODE_VALUE = 599;
+    public const MAX_STATUS_CODE_VALUE = 599;
 
-    /**
-     * @var array Recommended Reason Phrases
-     */
+    /** @var array Recommended Reason Phrases */
     protected $recommendedReasonPhrases = [
         // INFORMATIONAL CODES
         100 => 'Continue',
@@ -174,14 +187,10 @@ class Response extends AbstractMessage implements ResponseInterface
         599 => 'Network Connect Timeout Error',
     ];
 
-    /**
-     * @var int Status code
-     */
+    /** @var int Status code */
     protected $statusCode = 200;
 
-    /**
-     * @var string|null Null means it will be looked up from the $reasonPhrase list above
-     */
+    /** @var string|null Null means it will be looked up from the $reasonPhrase list above */
     protected $reasonPhrase;
 
     /**
@@ -217,7 +226,7 @@ class Response extends AbstractMessage implements ResponseInterface
         }
 
         $isHeader = true;
-        $headers = $content = [];
+        $headers  = $content = [];
 
         foreach ($lines as $line) {
             if ($isHeader && $line === '') {
@@ -233,7 +242,8 @@ class Response extends AbstractMessage implements ResponseInterface
                 continue;
             }
 
-            if (empty($content)
+            if (
+                empty($content)
                 && preg_match('/^[a-z0-9!#$%&\'*+.^_`|~-]+:$/i', $line)
             ) {
                 throw new Exception\RuntimeException('CRLF injection detected');
@@ -256,7 +266,7 @@ class Response extends AbstractMessage implements ResponseInterface
     /**
      * @param string $line
      * @throws Exception\InvalidArgumentException
-     * @throws Exception\RuntimeException
+     * @throws RuntimeException
      */
     protected function parseStatusLine($line)
     {
@@ -270,7 +280,7 @@ class Response extends AbstractMessage implements ResponseInterface
 
         $this->version = $matches['version'];
         $this->setStatusCode($matches['status']);
-        $this->setReasonPhrase((isset($matches['reason']) ? $matches['reason'] : ''));
+        $this->setReasonPhrase($matches['reason'] ?? '');
     }
 
     /**
@@ -290,7 +300,8 @@ class Response extends AbstractMessage implements ResponseInterface
      */
     public function setStatusCode($code)
     {
-        if (! is_numeric($code)
+        if (
+            ! is_numeric($code)
             || is_float($code)
             || $code < static::MIN_STATUS_CODE_VALUE
             || $code > static::MAX_STATUS_CODE_VALUE
@@ -345,7 +356,7 @@ class Response extends AbstractMessage implements ResponseInterface
     protected function saveStatusCode($code)
     {
         $this->reasonPhrase = null;
-        $this->statusCode = (int) $code;
+        $this->statusCode   = (int) $code;
         return $this;
     }
 
@@ -366,7 +377,7 @@ class Response extends AbstractMessage implements ResponseInterface
      */
     public function getReasonPhrase()
     {
-        if (null == $this->reasonPhrase && isset($this->recommendedReasonPhrases[$this->statusCode])) {
+        if (empty($this->reasonPhrase) && isset($this->recommendedReasonPhrases[$this->statusCode])) {
             $this->reasonPhrase = $this->recommendedReasonPhrases[$this->statusCode];
         }
         return $this->reasonPhrase;
@@ -411,7 +422,7 @@ class Response extends AbstractMessage implements ResponseInterface
     public function isClientError()
     {
         $code = $this->getStatusCode();
-        return ($code < 500 && $code >= 400);
+        return $code < 500 && $code >= 400;
     }
 
     /**
@@ -421,7 +432,7 @@ class Response extends AbstractMessage implements ResponseInterface
      */
     public function isForbidden()
     {
-        return (403 === $this->getStatusCode());
+        return 403 === $this->getStatusCode();
     }
 
     /**
@@ -432,7 +443,7 @@ class Response extends AbstractMessage implements ResponseInterface
     public function isInformational()
     {
         $code = $this->getStatusCode();
-        return ($code >= 100 && $code < 200);
+        return $code >= 100 && $code < 200;
     }
 
     /**
@@ -442,7 +453,7 @@ class Response extends AbstractMessage implements ResponseInterface
      */
     public function isNotFound()
     {
-        return (404 === $this->getStatusCode());
+        return 404 === $this->getStatusCode();
     }
 
     /**
@@ -452,7 +463,7 @@ class Response extends AbstractMessage implements ResponseInterface
      */
     public function isGone()
     {
-        return (410 === $this->getStatusCode());
+        return 410 === $this->getStatusCode();
     }
 
     /**
@@ -462,7 +473,7 @@ class Response extends AbstractMessage implements ResponseInterface
      */
     public function isOk()
     {
-        return (200 === $this->getStatusCode());
+        return 200 === $this->getStatusCode();
     }
 
     /**
@@ -473,7 +484,7 @@ class Response extends AbstractMessage implements ResponseInterface
     public function isServerError()
     {
         $code = $this->getStatusCode();
-        return (500 <= $code && 600 > $code);
+        return 500 <= $code && 600 > $code;
     }
 
     /**
@@ -484,7 +495,7 @@ class Response extends AbstractMessage implements ResponseInterface
     public function isRedirect()
     {
         $code = $this->getStatusCode();
-        return (300 <= $code && 400 > $code);
+        return 300 <= $code && 400 > $code;
     }
 
     /**
@@ -495,7 +506,7 @@ class Response extends AbstractMessage implements ResponseInterface
     public function isSuccess()
     {
         $code = $this->getStatusCode();
-        return (200 <= $code && 300 > $code);
+        return 200 <= $code && 300 > $code;
     }
 
     /**
@@ -533,7 +544,7 @@ class Response extends AbstractMessage implements ResponseInterface
      *
      * @param  string $body
      * @return string
-     * @throws Exception\RuntimeException
+     * @throws RuntimeException
      */
     protected function decodeChunkedBody($body)
     {
@@ -556,7 +567,7 @@ class Response extends AbstractMessage implements ResponseInterface
             $length   = hexdec(trim($m[1]));
             $cut      = strlen($m[0]);
             $decBody .= substr($body, $offset + $cut, $length);
-            $offset += $cut + $length + 2;
+            $offset  += $cut + $length + 2;
         }
 
         return $decBody;
@@ -569,7 +580,7 @@ class Response extends AbstractMessage implements ResponseInterface
      *
      * @param  string $body
      * @return string
-     * @throws Exception\RuntimeException
+     * @throws RuntimeException
      */
     protected function decodeGzip($body)
     {
@@ -579,7 +590,8 @@ class Response extends AbstractMessage implements ResponseInterface
             );
         }
 
-        if ($body === ''
+        if (
+            $body === ''
             || ($this->getHeaders()->has('content-length')
                 && (int) $this->getHeaders()->get('content-length')->getFieldValue() === 0)
         ) {
@@ -588,7 +600,7 @@ class Response extends AbstractMessage implements ResponseInterface
 
         ErrorHandler::start();
         $return = gzinflate(substr($body, 10));
-        $test = ErrorHandler::stop();
+        $test   = ErrorHandler::stop();
         if ($test) {
             throw new Exception\RuntimeException(
                 'Error occurred during gzip inflation',
@@ -606,7 +618,7 @@ class Response extends AbstractMessage implements ResponseInterface
      *
      * @param  string $body
      * @return string
-     * @throws Exception\RuntimeException
+     * @throws RuntimeException
      */
     protected function decodeDeflate($body)
     {
@@ -616,8 +628,10 @@ class Response extends AbstractMessage implements ResponseInterface
             );
         }
 
-        if ($this->getHeaders()->has('content-length')
-            && 0 === (int) $this->getHeaders()->get('content-length')->getFieldValue()) {
+        if (
+            $this->getHeaders()->has('content-length')
+            && 0 === (int) $this->getHeaders()->get('content-length')->getFieldValue()
+        ) {
             return '';
         }
 

--- a/src/Response/Stream.php
+++ b/src/Response/Stream.php
@@ -1,16 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Response;
 
 use Laminas\Http\Exception;
+use Laminas\Http\Header\ContentLength;
 use Laminas\Http\Response;
 use Laminas\Stdlib\ErrorHandler;
+
+use function array_shift;
+use function explode;
+use function fgets;
+use function file_exists;
+use function get_resource_type;
+use function implode;
+use function is_resource;
+use function is_string;
+use function sprintf;
+use function stream_get_contents;
+use function strlen;
+use function trim;
+use function unlink;
+
+use const E_WARNING;
 
 /**
  * Represents an HTTP response message as PHP stream resource
@@ -165,7 +176,7 @@ class Stream extends Response
             $nextLine        = array_shift($responseArray);
             $headersString  .= $nextLine . "\n";
             $nextLineTrimmed = trim($nextLine);
-            if ($nextLineTrimmed == '') {
+            if ($nextLineTrimmed === '') {
                 $headerComplete = true;
                 break;
             }
@@ -174,7 +185,7 @@ class Stream extends Response
         if (! $headerComplete) {
             while (false !== ($nextLine = fgets($stream))) {
                 $headersString .= trim($nextLine) . "\r\n";
-                if ($nextLine == "\r\n" || $nextLine == "\n") {
+                if ($nextLine === "\r\n" || $nextLine === "\n") {
                     $headerComplete = true;
                     break;
                 }
@@ -198,7 +209,7 @@ class Stream extends Response
 
         $headers = $response->getHeaders();
         foreach ($headers as $header) {
-            if ($header instanceof \Laminas\Http\Header\ContentLength) {
+            if ($header instanceof ContentLength) {
                 $response->setContentLength((int) $header->getFieldValue());
                 $contentLength = $response->getContentLength();
                 if (strlen($response->content) > $contentLength) {
@@ -267,14 +278,14 @@ class Stream extends Response
             $bytes = -1; // Read the whole buffer
         }
 
-        if (! is_resource($this->stream) || $bytes == 0) {
+        if (! is_resource($this->stream) || $bytes === 0) {
             return '';
         }
 
         $this->content         .= stream_get_contents($this->stream, $bytes);
         $this->contentStreamed += strlen($this->content);
 
-        if ($this->getContentLength() == $this->contentStreamed) {
+        if ($this->getContentLength() === $this->contentStreamed) {
             $this->stream = null;
         }
     }

--- a/test/Client/CurlTest.php
+++ b/test/Client/CurlTest.php
@@ -8,7 +8,7 @@
 
 namespace LaminasTest\Http\Client;
 
-use Laminas\Config\Config;
+use ArrayObject;
 use Laminas\Http\Client;
 use Laminas\Http\Client\Adapter;
 use Laminas\Http\Client\Adapter\Curl;
@@ -78,13 +78,13 @@ class CurlTest extends CommonHttpTests
     }
 
     /**
-     * Test that a Laminas_Config object can be used to set configuration
+     * Test that a Traversable object can be used to set configuration
      *
-     * @link https://getlaminas.org/issues/browse/Laminas-5577
+     * @link https://framework.zend.com/issues/browse/ZEND-5577
      */
-    public function testConfigSetAsLaminasConfig()
+    public function testConfigSetAsTraversable()
     {
-        $config = new Config([
+        $config = new ArrayObject([
             'timeout'  => 400,
             'nested'   => [
                 'item' => 'value',

--- a/test/Client/CurlTest.php
+++ b/test/Client/CurlTest.php
@@ -111,13 +111,13 @@ class CurlTest extends CommonHttpTests
             'nested'  => [
                 'item' => 'value',
             ],
-        ], ArrayObject::ARRAY_AS_PROPS);
+        ]);
 
         $this->adapter->setOptions($config);
 
         $hasConfig = $this->adapter->getConfig();
-        $this->assertEquals($config->timeout, $hasConfig['timeout']);
-        $this->assertEquals($config->nested->item, $hasConfig['nested']['item']);
+        $this->assertEquals($config['timeout'], $hasConfig['timeout']);
+        $this->assertEquals($config['nested']['item'], $hasConfig['nested']['item']);
     }
 
     /** @psalm-return array<string, array{0: int|string}> */
@@ -584,6 +584,6 @@ class CurlTest extends CommonHttpTests
         $response = $this->client->getResponse();
 
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('HTTP/1.1 200 OK', trim(strstr($response, "\n", true)));
+        $this->assertMatchesRegularExpression('#^HTTP/1.(0|1) 200 OK$#', trim(strstr($response, "\n", true)));
     }
 }

--- a/test/Client/CurlTest.php
+++ b/test/Client/CurlTest.php
@@ -1,14 +1,9 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Client;
 
 use ArrayObject;
+use Exception;
 use Laminas\Http\Client;
 use Laminas\Http\Client\Adapter;
 use Laminas\Http\Client\Adapter\Curl;
@@ -16,6 +11,33 @@ use Laminas\Http\Client\Adapter\Exception\InvalidArgumentException;
 use Laminas\Http\Client\Adapter\Exception\RuntimeException;
 use Laminas\Http\Client\Adapter\Exception\TimeoutException;
 use Laminas\Stdlib\ErrorHandler;
+use ValueError;
+
+use function base64_encode;
+use function curl_getinfo;
+use function explode;
+use function extension_loaded;
+use function file_get_contents;
+use function filesize;
+use function fopen;
+use function getenv;
+use function gzcompress;
+use function strstr;
+use function trim;
+
+use const CURLOPT_ENCODING;
+use const CURLOPT_FOLLOWLOCATION;
+use const CURLOPT_INFILE;
+use const CURLOPT_INFILESIZE;
+use const CURLOPT_POSTFIELDS;
+use const CURLOPT_PROXY;
+use const CURLOPT_PROXYPORT;
+use const CURLOPT_PROXYUSERPWD;
+use const CURLOPT_SSL_VERIFYPEER;
+use const CURLOPT_TIMEOUT;
+use const DIRECTORY_SEPARATOR;
+use const PHP_INT_MAX;
+use const PHP_VERSION_ID;
 
 /**
  * This Testsuite includes all Laminas_Http_Client that require a working web
@@ -69,9 +91,9 @@ class CurlTest extends CommonHttpTests
             'someoption' => 'hasvalue',
         ];
 
-        $this->_adapter->setOptions($config);
+        $this->adapter->setOptions($config);
 
-        $hasConfig = $this->_adapter->getConfig();
+        $hasConfig = $this->adapter->getConfig();
         foreach ($config as $k => $v) {
             $this->assertEquals($v, $hasConfig[$k]);
         }
@@ -85,20 +107,21 @@ class CurlTest extends CommonHttpTests
     public function testConfigSetAsTraversable()
     {
         $config = new ArrayObject([
-            'timeout'  => 400,
-            'nested'   => [
+            'timeout' => 400,
+            'nested'  => [
                 'item' => 'value',
             ],
-        ]);
+        ], ArrayObject::ARRAY_AS_PROPS);
 
-        $this->_adapter->setOptions($config);
+        $this->adapter->setOptions($config);
 
-        $hasConfig = $this->_adapter->getConfig();
+        $hasConfig = $this->adapter->getConfig();
         $this->assertEquals($config->timeout, $hasConfig['timeout']);
         $this->assertEquals($config->nested->item, $hasConfig['nested']['item']);
     }
 
-    public function provideValidTimeoutConfig()
+    /** @psalm-return array<string, array{0: int|string}> */
+    public function provideValidTimeoutConfig(): array
     {
         return [
             'integer' => [10],
@@ -108,6 +131,7 @@ class CurlTest extends CommonHttpTests
 
     /**
      * @dataProvider provideValidTimeoutConfig
+     * @param int|string $timeout
      */
     public function testPassValidTimeout($timeout)
     {
@@ -132,7 +156,6 @@ class CurlTest extends CommonHttpTests
      * Check that an exception is thrown when trying to set invalid config
      *
      * @dataProvider invalidConfigProvider
-     *
      * @param mixed $config
      */
     public function testSetConfigInvalidConfig($config)
@@ -140,12 +163,12 @@ class CurlTest extends CommonHttpTests
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Array or Traversable object expected');
 
-        $this->_adapter->setOptions($config);
+        $this->adapter->setOptions($config);
     }
 
     public function testSettingInvalidCurlOption()
     {
-        $config = [
+        $config       = [
             'adapter'     => Curl::class,
             'curloptions' => [-PHP_INT_MAX => true],
         ];
@@ -158,7 +181,7 @@ class CurlTest extends CommonHttpTests
             $this->expectException(RuntimeException::class);
             $this->expectExceptionMessage('Unknown or erroreous cURL option');
         } else {
-            $this->expectException(\ValueError::class);
+            $this->expectException(ValueError::class);
             $this->expectExceptionMessage('curl_setopt(): Argument #2 ($option) is not a valid cURL option');
         }
         try {
@@ -216,8 +239,9 @@ class CurlTest extends CommonHttpTests
     }
 
     /**
-     * @group Laminas-3758
      * @link https://getlaminas.org/issues/browse/Laminas-3758
+     *
+     * @group Laminas-3758
      */
     public function testPutFileContentWithHttpClient()
     {
@@ -232,8 +256,9 @@ class CurlTest extends CommonHttpTests
     }
 
     /**
-     * @group Laminas-3758
      * @link https://getlaminas.org/issues/browse/Laminas-3758
+     *
+     * @group Laminas-3758
      */
     public function testPutFileHandleWithHttpClient()
     {
@@ -241,9 +266,9 @@ class CurlTest extends CommonHttpTests
         $putFileContents = file_get_contents(__DIR__ . '/_files/staticFile.jpg');
 
         // Method 2: Using a File-Handle to the file to PUT the data
-        $putFilePath = __DIR__ . '/_files/staticFile.jpg';
+        $putFilePath   = __DIR__ . '/_files/staticFile.jpg';
         $putFileHandle = fopen($putFilePath, 'r');
-        $putFileSize = filesize($putFilePath);
+        $putFileSize   = filesize($putFilePath);
 
         $adapter = new Adapter\Curl();
         $this->client->setAdapter($adapter);
@@ -323,8 +348,8 @@ class CurlTest extends CommonHttpTests
         $expected = [
             'curloptions' => [
                 CURLOPT_PROXYUSERPWD => 'foo:baz',
-                CURLOPT_PROXY => 'localhost',
-                CURLOPT_PROXYPORT => 80,
+                CURLOPT_PROXY        => 'localhost',
+                CURLOPT_PROXYPORT    => 80,
             ],
         ];
 
@@ -455,10 +480,11 @@ class CurlTest extends CommonHttpTests
     }
 
     /**
-     * @group Laminas-7683
      * @see https://github.com/zendframework/zend-http/pull/53
      *
      * Note: The headers stored in Laminas7683-chunked.php are case insensitive
+     *
+     * @group Laminas-7683
      */
     public function testNoCaseSensitiveHeaderName()
     {
@@ -528,7 +554,7 @@ class CurlTest extends CommonHttpTests
         $error = null;
         try {
             $this->client->send();
-        } catch (\Exception $x) {
+        } catch (Exception $x) {
             $error = $x;
         }
         $this->assertNotNull($error, 'Failed to detect timeout in cURL adapter');
@@ -544,7 +570,7 @@ class CurlTest extends CommonHttpTests
             $this->markTestSkipped('Proxy is not configured');
         }
 
-        list($proxyHost, $proxyPort) = explode(':', $proxy);
+        [$proxyHost, $proxyPort] = explode(':', $proxy);
 
         $this->client->setAdapter(new Adapter\Curl());
         $this->client->setOptions([

--- a/test/Client/ProxyAdapterTest.php
+++ b/test/Client/ProxyAdapterTest.php
@@ -1,16 +1,20 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Client;
 
 use Laminas\Http\Client;
 use Laminas\Http\Client\Adapter\Proxy;
 use Laminas\Http\Client\Adapter\Socket;
+use Laminas\Http\Request;
+
+use function array_keys;
+use function explode;
+use function filter_var;
+use function getenv;
+use function sprintf;
+use function trim;
+
+use const FILTER_VALIDATE_BOOLEAN;
 
 /**
  * Laminas_Http_Client_Adapter_Proxy test suite.
@@ -33,10 +37,11 @@ class ProxyAdapterTest extends SocketTest
 
     protected function setUp(): void
     {
-        if (getenv('TESTS_LAMINAS_HTTP_CLIENT_HTTP_PROXY')
+        if (
+            getenv('TESTS_LAMINAS_HTTP_CLIENT_HTTP_PROXY')
             && filter_var(getenv('TESTS_LAMINAS_HTTP_CLIENT_HTTP_PROXY'), FILTER_VALIDATE_BOOLEAN) === false
         ) {
-            list($host, $port) = explode(':', getenv('TESTS_LAMINAS_HTTP_CLIENT_HTTP_PROXY'), 2);
+            [$host, $port] = explode(':', getenv('TESTS_LAMINAS_HTTP_CLIENT_HTTP_PROXY'), 2);
 
             if (! $host) {
                 $this->markTestSkipped('No valid proxy host name or address specified.');
@@ -81,13 +86,13 @@ class ProxyAdapterTest extends SocketTest
      */
     public function testFallbackToSocket()
     {
-        $this->_adapter->setOptions([
+        $this->adapter->setOptions([
             'proxy_host' => null,
         ]);
 
         $this->client->setUri($this->baseuri . 'testGetLastRequest.php');
-        $res = $this->client->setMethod(\Laminas\Http\Request::METHOD_TRACE)->send();
-        if ($res->getStatusCode() == 405 || $res->getStatusCode() == 501) {
+        $res = $this->client->setMethod(Request::METHOD_TRACE)->send();
+        if ($res->getStatusCode() === 405 || $res->getStatusCode() === 501) {
             $this->markTestSkipped('Server does not allow the TRACE method');
         }
 
@@ -107,7 +112,7 @@ class ProxyAdapterTest extends SocketTest
 
     public function testDefaultConfig()
     {
-        $config = $this->_adapter->getConfig();
+        $config = $this->adapter->getConfig();
         $this->assertEquals(true, $config['sslverifypeer']);
         $this->assertEquals(false, $config['sslallowselfsigned']);
     }
@@ -141,12 +146,12 @@ class ProxyAdapterTest extends SocketTest
 
         $this->client->setMethod('TRACE');
         $res = $this->client->send();
-        if ($res->getStatusCode() == 405 || $res->getStatusCode() == 501) {
+        if ($res->getStatusCode() === 405 || $res->getStatusCode() === 501) {
             $this->markTestSkipped('Server does not allow the TRACE method');
         }
 
-        list($schema, $host) = explode('://', $this->baseuri);
-        $host = trim($host, '/');
+        [$schema, $host] = explode('://', $this->baseuri);
+        $host            = trim($host, '/');
 
         $this->assertSame(
             'TRACE ' . $this->baseuri . 'testHeaders.php?someinput=somevalue HTTP/1.1' . "\r\n"
@@ -174,9 +179,9 @@ class ProxyAdapterTest extends SocketTest
      */
     public function testProxyKeysCorrectlySetInProxyAdapter()
     {
-        $adapterConfig = $this->_adapter->getConfig();
-        $adapterHost = $adapterConfig['proxy_host'];
-        $adapterPort = $adapterConfig['proxy_port'];
+        $adapterConfig = $this->adapter->getConfig();
+        $adapterHost   = $adapterConfig['proxy_host'];
+        $adapterPort   = $adapterConfig['proxy_port'];
 
         $this->assertSame($this->host, $adapterHost);
         $this->assertSame($this->port, $adapterPort);
@@ -184,10 +189,10 @@ class ProxyAdapterTest extends SocketTest
 
     public function testProxyHasAllSocketConfigs()
     {
-        $socket = new Socket();
+        $socket       = new Socket();
         $socketConfig = $socket->getConfig();
-        $proxy = new Proxy();
-        $proxyConfig = $proxy->getConfig();
+        $proxy        = new Proxy();
+        $proxyConfig  = $proxy->getConfig();
         foreach (array_keys($socketConfig) as $socketConfigKey) {
             $this->assertArrayHasKey(
                 $socketConfigKey,

--- a/test/Client/SocketKeepaliveTest.php
+++ b/test/Client/SocketKeepaliveTest.php
@@ -1,12 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Client;
+
+use Laminas\Http\Client\Adapter\Socket;
 
 /**
  * This Testsuite includes all Laminas_Http_Client that require a working web
@@ -24,8 +20,6 @@ namespace LaminasTest\Http\Client;
  * @group      Laminas_Http
  * @group      Laminas_Http_Client
  */
-use Laminas\Http\Client\Adapter\Socket;
-
 class SocketKeepaliveTest extends SocketTest
 {
     /**

--- a/test/Client/SocketPersistentTest.php
+++ b/test/Client/SocketPersistentTest.php
@@ -1,12 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Client;
+
+use Laminas\Http\Client\Adapter\Socket;
 
 /**
  * This Testsuite includes all Laminas_Http_Client that require a working web
@@ -24,8 +20,6 @@ namespace LaminasTest\Http\Client;
  * @group      Laminas_Http
  * @group      Laminas_Http_Client
  */
-use Laminas\Http\Client\Adapter\Socket;
-
 class SocketPersistentTest extends SocketTest
 {
     /**

--- a/test/Client/SocketTest.php
+++ b/test/Client/SocketTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Client;
 
 use ArrayObject;
@@ -15,6 +9,13 @@ use Laminas\Http\Client\Adapter\Exception\RuntimeException;
 use Laminas\Http\Client\Adapter\Socket;
 use Laminas\Uri\Uri;
 use stdClass;
+
+use function fopen;
+use function get_resource_type;
+use function md5;
+use function microtime;
+use function stream_context_create;
+use function stream_context_get_options;
 
 /**
  * This Testsuite includes all Laminas_Http_Client that require a working web
@@ -49,6 +50,7 @@ class SocketTest extends CommonHttpTests
 
     /**
      * Test that we can set a valid configuration array with some options
+     *
      * @group ZHC001
      */
     public function testConfigSetAsArray()
@@ -58,9 +60,9 @@ class SocketTest extends CommonHttpTests
             'someoption' => 'hasvalue',
         ];
 
-        $this->_adapter->setOptions($config);
+        $this->adapter->setOptions($config);
 
-        $hasConfig = $this->_adapter->getConfig();
+        $hasConfig = $this->adapter->getConfig();
         foreach ($config as $k => $v) {
             $this->assertEquals($v, $hasConfig[$k]);
         }
@@ -68,7 +70,7 @@ class SocketTest extends CommonHttpTests
 
     public function testDefaultConfig()
     {
-        $config = $this->_adapter->getConfig();
+        $config = $this->adapter->getConfig();
         $this->assertEquals(true, $config['sslverifypeer']);
         $this->assertEquals(false, $config['sslallowselfsigned']);
         $this->assertEquals(true, $config['sslverifypeername']);
@@ -77,14 +79,14 @@ class SocketTest extends CommonHttpTests
     public function testConnectingViaSslEnforcesDefaultSslOptionsOnContext()
     {
         $config = ['timeout' => 30];
-        $this->_adapter->setOptions($config);
+        $this->adapter->setOptions($config);
         try {
-            $this->_adapter->connect('localhost', 443, true);
+            $this->adapter->connect('localhost', 443, true);
         } catch (RuntimeException $e) {
             // Test is designed to allow connect failure because we're interested
             // only in the stream context state created within that method.
         }
-        $context = $this->_adapter->getStreamContext();
+        $context = $this->adapter->getStreamContext();
         $options = stream_context_get_options($context);
         $this->assertTrue($options['ssl']['verify_peer']);
         $this->assertFalse($options['ssl']['allow_self_signed']);
@@ -99,14 +101,14 @@ class SocketTest extends CommonHttpTests
             'sslallowselfsigned' => true,
             'sslverifypeername'  => false,
         ];
-        $this->_adapter->setOptions($config);
+        $this->adapter->setOptions($config);
         try {
-            $this->_adapter->connect('localhost', 443, true);
+            $this->adapter->connect('localhost', 443, true);
         } catch (RuntimeException $e) {
             // Test is designed to allow connect failure because we're interested
             // only in the stream context state created within that method.
         }
-        $context = $this->_adapter->getStreamContext();
+        $context = $this->adapter->getStreamContext();
         $options = stream_context_get_options($context);
         $this->assertFalse($options['ssl']['verify_peer']);
         $this->assertTrue($options['ssl']['allow_self_signed']);
@@ -124,14 +126,14 @@ class SocketTest extends CommonHttpTests
             'timeout'   => 30,
             'sslcafile' => __DIR__ . '/_files/ca-bundle.crt',
         ];
-        $this->_adapter->setOptions($config);
+        $this->adapter->setOptions($config);
         try {
-            $this->_adapter->connect('localhost', 443, true);
+            $this->adapter->connect('localhost', 443, true);
         } catch (RuntimeException $e) {
             // Test is designed to allow connect failure because we're interested
             // only in the stream context state created within that method.
         }
-        $context = $this->_adapter->getStreamContext();
+        $context = $this->adapter->getStreamContext();
         $options = stream_context_get_options($context);
         $this->assertEquals($config['sslcafile'], $options['ssl']['cafile']);
     }
@@ -144,15 +146,15 @@ class SocketTest extends CommonHttpTests
     public function testConfigSetAsTraversable()
     {
         $config = new ArrayObject([
-            'timeout'  => 400,
-            'nested'   => [
+            'timeout' => 400,
+            'nested'  => [
                 'item' => 'value',
             ],
-        ]);
+        ], ArrayObject::ARRAY_AS_PROPS);
 
-        $this->_adapter->setOptions($config);
+        $this->adapter->setOptions($config);
 
-        $hasConfig = $this->_adapter->getConfig();
+        $hasConfig = $this->adapter->getConfig();
         $this->assertEquals($config->timeout, $hasConfig['timeout']);
         $this->assertEquals($config->nested->item, $hasConfig['nested']['item']);
     }
@@ -161,7 +163,6 @@ class SocketTest extends CommonHttpTests
      * Check that an exception is thrown when trying to set invalid config
      *
      * @dataProvider invalidConfigProvider
-     *
      * @param mixed $config
      */
     public function testSetConfigInvalidConfig($config)
@@ -169,10 +170,11 @@ class SocketTest extends CommonHttpTests
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Array or Laminas\Config object expected');
 
-        $this->_adapter->setOptions($config);
+        $this->adapter->setOptions($config);
     }
 
-    public function provideValidTimeoutConfig()
+    /** @psalm-return array<string, array{0: int|string}> */
+    public function provideValidTimeoutConfig(): array
     {
         return [
             'integer' => [10],
@@ -182,6 +184,7 @@ class SocketTest extends CommonHttpTests
 
     /**
      * @dataProvider provideValidTimeoutConfig
+     * @param int|string $timeout
      */
     public function testPassValidTimeout($timeout)
     {
@@ -202,15 +205,14 @@ class SocketTest extends CommonHttpTests
         $adapter->connect('getlaminas.org');
     }
 
-    /**
-     * Stream context related tests
-     */
+    // Stream context related tests
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testGetNewStreamContext()
     {
         $adapterClass = $this->config['adapter'];
-        $adapter = new $adapterClass();
-        $context = $adapter->getStreamContext();
+        $adapter      = new $adapterClass();
+        $context      = $adapter->getStreamContext();
 
         $this->assertEquals('stream-context', get_resource_type($context));
     }
@@ -218,8 +220,8 @@ class SocketTest extends CommonHttpTests
     public function testSetNewStreamContextResource()
     {
         $adapterClass = $this->config['adapter'];
-        $adapter = new $adapterClass();
-        $context = stream_context_create();
+        $adapter      = new $adapterClass();
+        $context      = stream_context_create();
 
         $adapter->setStreamContext($context);
 
@@ -229,12 +231,12 @@ class SocketTest extends CommonHttpTests
     public function testSetNewStreamContextOptions()
     {
         $adapterClass = $this->config['adapter'];
-        $adapter = new $adapterClass();
-        $options = [
+        $adapter      = new $adapterClass();
+        $options      = [
             'socket' => [
                 'bindto' => '1.2.3.4:0',
             ],
-            'ssl' => [
+            'ssl'    => [
                 'capath'            => null,
                 'verify_peer'       => true,
                 'allow_self_signed' => false,
@@ -251,7 +253,6 @@ class SocketTest extends CommonHttpTests
      * Test that setting invalid options / context causes an exception
      *
      * @dataProvider invalidContextProvider
-     *
      * @param mixed $invalid
      */
     public function testSetInvalidContextOptions($invalid)
@@ -260,21 +261,21 @@ class SocketTest extends CommonHttpTests
         $this->expectExceptionMessage('Expecting either a stream context resource or array');
 
         $adapterClass = $this->config['adapter'];
-        $adapter = new $adapterClass();
+        $adapter      = new $adapterClass();
         $adapter->setStreamContext($invalid);
     }
 
     public function testSetHttpsStreamContextParam()
     {
-        if ($this->client->getUri()->getScheme() != 'https') {
+        if ($this->client->getUri()->getScheme() !== 'https') {
             $this->markTestSkipped();
         }
 
         $adapterClass = $this->config['adapter'];
-        $adapter = new $adapterClass();
+        $adapter      = new $adapterClass();
         $adapter->setStreamContext([
             'ssl' => [
-                'capture_peer_cert' => true,
+                'capture_peer_cert'  => true,
                 'capture_peer_chain' => true,
             ],
         ]);
@@ -306,7 +307,7 @@ class SocketTest extends CommonHttpTests
             $this->assertEquals(Adapter\Exception\TimeoutException::READ_TIMEOUT, $e->getCode());
         }
 
-        $time = (microtime(true) - $start);
+        $time = microtime(true) - $start;
 
         // We should be very close to 1 second
         $this->assertLessThan(2, $time);
@@ -337,9 +338,9 @@ class SocketTest extends CommonHttpTests
      */
     public function testAllowsZeroWrittenBytes()
     {
-        $this->_adapter->connect('localhost');
+        $this->adapter->connect('localhost');
         require_once __DIR__ . '/_files/fwrite.php';
-        $this->_adapter->write('GET', new Uri('tcp://localhost:80/'), '1.1', [], 'test body');
+        $this->adapter->write('GET', new Uri('tcp://localhost:80/'), '1.1', [], 'test body');
     }
 
     /**
@@ -348,8 +349,8 @@ class SocketTest extends CommonHttpTests
      */
     public function testCaseInsensitiveHeaders()
     {
-        $this->_adapter->connect('localhost');
-        $requestString = $this->_adapter->write(
+        $this->adapter->connect('localhost');
+        $requestString = $this->adapter->write(
             'GET',
             new Uri('tcp://localhost:80/'),
             '1.1',

--- a/test/Client/SocketTest.php
+++ b/test/Client/SocketTest.php
@@ -150,13 +150,13 @@ class SocketTest extends CommonHttpTests
             'nested'  => [
                 'item' => 'value',
             ],
-        ], ArrayObject::ARRAY_AS_PROPS);
+        ]);
 
         $this->adapter->setOptions($config);
 
         $hasConfig = $this->adapter->getConfig();
-        $this->assertEquals($config->timeout, $hasConfig['timeout']);
-        $this->assertEquals($config->nested->item, $hasConfig['nested']['item']);
+        $this->assertEquals($config['timeout'], $hasConfig['timeout']);
+        $this->assertEquals($config['nested']['item'], $hasConfig['nested']['item']);
     }
 
     /**

--- a/test/Client/SocketTest.php
+++ b/test/Client/SocketTest.php
@@ -8,7 +8,7 @@
 
 namespace LaminasTest\Http\Client;
 
-use Laminas\Config\Config;
+use ArrayObject;
 use Laminas\Http\Client\Adapter;
 use Laminas\Http\Client\Adapter\Exception\InvalidArgumentException;
 use Laminas\Http\Client\Adapter\Exception\RuntimeException;
@@ -137,13 +137,13 @@ class SocketTest extends CommonHttpTests
     }
 
     /**
-     * Test that a Laminas\Config object can be used to set configuration
+     * Test that a Traversable object can be used to set configuration
      *
-     * @link https://getlaminas.org/issues/browse/Laminas-5577
+     * @link https://framework.zend.com/issues/browse/ZEND-5577
      */
-    public function testConfigSetAsLaminasConfig()
+    public function testConfigSetAsTraversable()
     {
-        $config = new Config([
+        $config = new ArrayObject([
             'timeout'  => 400,
             'nested'   => [
                 'item' => 'value',

--- a/test/Client/StaticClientTest.php
+++ b/test/Client/StaticClientTest.php
@@ -1,17 +1,18 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Client;
 
 use Laminas\Http\Client;
 use Laminas\Http\ClientStatic as HTTPClient;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+
+use function filter_var;
+use function getenv;
+use function sprintf;
+use function substr;
+
+use const FILTER_VALIDATE_BOOLEAN;
 
 /**
  * This are the test for the prototype of Laminas\Http\Client
@@ -33,10 +34,12 @@ class StaticClientTest extends TestCase
      */
     protected function setUp(): void
     {
-        if (getenv('TESTS_LAMINAS_HTTP_CLIENT_BASEURI')
-            && (filter_var(getenv('TESTS_LAMINAS_HTTP_CLIENT_BASEURI'), FILTER_VALIDATE_BOOLEAN) != false)) {
+        if (
+            getenv('TESTS_LAMINAS_HTTP_CLIENT_BASEURI')
+            && (filter_var(getenv('TESTS_LAMINAS_HTTP_CLIENT_BASEURI'), FILTER_VALIDATE_BOOLEAN) !== false)
+        ) {
             $this->baseuri = getenv('TESTS_LAMINAS_HTTP_CLIENT_BASEURI');
-            if (substr($this->baseuri, -1) != '/') {
+            if (substr($this->baseuri, -1) !== '/') {
                 $this->baseuri .= '/';
             }
         } else {
@@ -158,7 +161,7 @@ class StaticClientTest extends TestCase
         HTTPClient::get($testUri, [], [], null, $config);
 
         $reflectedClass = new ReflectionClass(HTTPClient::class);
-        $property = $reflectedClass->getProperty('client');
+        $property       = $reflectedClass->getProperty('client');
         $property->setAccessible(true);
         $client = $property->getValue();
 
@@ -183,7 +186,7 @@ class StaticClientTest extends TestCase
         HTTPClient::post($testUri, ['foo' => 'bar'], [], null, $config);
 
         $reflectedClass = new ReflectionClass(HTTPClient::class);
-        $property = $reflectedClass->getProperty('client');
+        $property       = $reflectedClass->getProperty('client');
         $property->setAccessible(true);
         $client = $property->getValue();
 

--- a/test/Client/StaticTest.php
+++ b/test/Client/StaticTest.php
@@ -8,7 +8,7 @@
 
 namespace LaminasTest\Http\Client;
 
-use Laminas\Config\Config;
+use ArrayObject;
 use Laminas\Http\Client\Adapter\Exception as ClientAdapterException;
 use Laminas\Http\Client\Adapter\Test;
 use Laminas\Http\Client as HTTPClient;
@@ -230,13 +230,13 @@ class StaticTest extends TestCase
     }
 
     /**
-     * Test that a Laminas_Config object can be used to set configuration
+     * Test that a Traversable object can be used to set configuration
      *
-     * @link https://getlaminas.org/issues/browse/Laminas-5577
+     * @link https://framework.zend.com/issues/browse/ZEND-5577
      */
-    public function testConfigSetAsLaminasConfig()
+    public function testConfigSetAsTraversable()
     {
-        $config = new Config([
+        $config = new ArrayObject([
             'timeout'  => 400,
             'nested'   => [
                 'item' => 'value',

--- a/test/Client/StaticTest.php
+++ b/test/Client/StaticTest.php
@@ -49,21 +49,19 @@ use const DIRECTORY_SEPARATOR;
  */
 class StaticTest extends TestCase
 {
-    // @codingStandardsIgnoreStart
     /**
      * Common HTTP client
      *
      * @var HTTPClient
      */
-    protected $_client;
-    // @codingStandardsIgnoreEnd
+    protected $client;
 
     /**
      * Set up the test suite before each test
      */
     public function setUp(): void
     {
-        $this->_client = new MockClient('http://www.example.com');
+        $this->client = new MockClient('http://www.example.com');
     }
 
     /**
@@ -71,7 +69,7 @@ class StaticTest extends TestCase
      */
     public function tearDown(): void
     {
-        $this->_client = null;
+        $this->client = null;
     }
 
     /**
@@ -85,13 +83,13 @@ class StaticTest extends TestCase
     {
         $uristr = 'https://www.zend.com:80/';
 
-        $this->_client->setUri($uristr);
+        $this->client->setUri($uristr);
 
-        $uri = $this->_client->getUri();
+        $uri = $this->client->getUri();
         $this->assertInstanceOf(UriHttp::class, $uri, 'Returned value is not a Uri object as expected');
         $this->assertEquals($uri->__toString(), $uristr, 'Returned Uri object does not hold the expected URI');
 
-        $uri = $this->_client->getUri()->toString();
+        $uri = $this->client->getUri()->toString();
         $this->assertIsString(
             $uri,
             'Returned value expected to be a string, ' . gettype($uri) . ' returned'
@@ -106,9 +104,9 @@ class StaticTest extends TestCase
     {
         $uriobj = new UriHttp('https://www.zend.com:80/');
 
-        $this->_client->setUri($uriobj);
+        $this->client->setUri($uriobj);
 
-        $uri = $this->_client->getUri();
+        $uri = $this->client->getUri();
         $this->assertInstanceOf(UriHttp::class, $uri, 'Returned value is not a Uri object as expected');
         $this->assertEquals($uri, $uriobj, 'Returned object is not the excepted Uri object');
     }
@@ -121,14 +119,14 @@ class StaticTest extends TestCase
     {
         $qstr = 'foo=bar&foo=baz';
 
-        $this->_client->setUri('http://example.com/test/?' . $qstr);
-        $this->_client->setAdapter(Test::class);
-        $this->_client->setMethod('GET');
-        $this->_client->send();
+        $this->client->setUri('http://example.com/test/?' . $qstr);
+        $this->client->setAdapter(Test::class);
+        $this->client->setMethod('GET');
+        $this->client->send();
 
         $this->assertStringContainsString(
             $qstr,
-            $this->_client->getLastRawRequest(),
+            $this->client->getLastRawRequest(),
             'Request is expected to contain the entire query string'
         );
     }
@@ -142,18 +140,18 @@ class StaticTest extends TestCase
      */
     public function testGetHeader()
     {
-        $this->_client->setHeaders([
+        $this->client->setHeaders([
             'Accept-encoding' => 'gzip,deflate',
             'Accept-language' => 'en,de,*',
         ]);
 
         $this->assertEquals(
-            $this->_client->getHeader('Accept-encoding'),
+            $this->client->getHeader('Accept-encoding'),
             'gzip, deflate',
             'Returned value of header is not as expected'
         );
         $this->assertEquals(
-            $this->_client->getHeader('X-Fake-Header'),
+            $this->client->getHeader('X-Fake-Header'),
             null,
             'Non-existing header should not return a value'
         );
@@ -172,7 +170,7 @@ class StaticTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid or not supported authentication type: \'SuperStrongAlgo\'');
 
-        $this->_client->setAuth('shahar', '1234', 'SuperStrongAlgo');
+        $this->client->setAuth('shahar', '1234', 'SuperStrongAlgo');
     }
 
     /**
@@ -184,9 +182,9 @@ class StaticTest extends TestCase
      */
     public function testSetNewCookies()
     {
-        $this->_client->addCookie('cookie', 'value');
-        $this->_client->addCookie('chocolate', 'chips');
-        $cookies = $this->_client->getCookies();
+        $this->client->addCookie('cookie', 'value');
+        $this->client->addCookie('chocolate', 'chips');
+        $cookies = $this->client->getCookies();
 
         // Check we got the right cookiejar
         $this->assertIsArray($cookies);
@@ -200,13 +198,13 @@ class StaticTest extends TestCase
     public function testUnsetCookies()
     {
         // Set the cookie jar just like in testSetNewCookieJar
-        $this->_client->addCookie('cookie', 'value');
-        $this->_client->addCookie('chocolate', 'chips');
-        $cookies = $this->_client->getCookies();
+        $this->client->addCookie('cookie', 'value');
+        $this->client->addCookie('chocolate', 'chips');
+        $cookies = $this->client->getCookies();
 
         // Try unsetting the cookies
-        $this->_client->clearCookies();
-        $cookies = $this->_client->getCookies();
+        $this->client->clearCookies();
+        $cookies = $this->client->getCookies();
 
         $this->assertEquals([], $cookies, 'Cookies are expected to be an empty array but it is not');
     }
@@ -219,7 +217,7 @@ class StaticTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid parameter type passed as Cookie');
 
-        $this->_client->addCookie('cookie');
+        $this->client->addCookie('cookie');
     }
 
     /**
@@ -236,9 +234,9 @@ class StaticTest extends TestCase
             'someoption' => 'hasvalue',
         ];
 
-        $this->_client->setOptions($config);
+        $this->client->setOptions($config);
 
-        $hasConfig = $this->_client->config;
+        $hasConfig = $this->client->config;
 
         foreach ($config as $k => $v) {
             $this->assertEquals($v, $hasConfig[$k]);
@@ -259,9 +257,9 @@ class StaticTest extends TestCase
             ],
         ]);
 
-        $this->_client->setOptions($config);
+        $this->client->setOptions($config);
 
-        $hasConfig = $this->_client->config;
+        $hasConfig = $this->client->config;
         $this->assertEquals($config['timeout'], $hasConfig['timeout']);
         $this->assertEquals($config['nested']['item'], $hasConfig['nested']['item']);
     }
@@ -277,7 +275,7 @@ class StaticTest extends TestCase
         $this->expectException(ClientException\InvalidArgumentException::class);
         $this->expectExceptionMessage('Config parameter is not valid');
 
-        $this->_client->setOptions($config);
+        $this->client->setOptions($config);
     }
 
     /**
@@ -291,13 +289,13 @@ class StaticTest extends TestCase
         $adapter = new MockAdapter();
 
         // test that config passes when we set the adapter
-        $this->_client->setOptions(['param' => 'value1']);
-        $this->_client->setAdapter($adapter);
+        $this->client->setOptions(['param' => 'value1']);
+        $this->client->setAdapter($adapter);
         $adapterCfg = $adapter->config;
         $this->assertEquals('value1', $adapterCfg['param']);
 
         // test that adapter config value changes when we set client config
-        $this->_client->setOptions(['param' => 'value2']);
+        $this->client->setOptions(['param' => 'value2']);
         $adapterCfg = $adapter->config;
         $this->assertEquals('value2', $adapterCfg['param']);
     }
@@ -314,18 +312,18 @@ class StaticTest extends TestCase
         // First, make sure we get null before the request
         $this->assertEquals(
             null,
-            $this->_client->getLastRawResponse(),
+            $this->client->getLastRawResponse(),
             'getLastRawResponse() is still expected to return null'
         );
 
         // Now, test we get a proper response after the request
-        $this->_client->setUri('http://example.com/foo/bar');
-        $this->_client->setAdapter(Test::class);
+        $this->client->setUri('http://example.com/foo/bar');
+        $this->client->setAdapter(Test::class);
 
-        $response = $this->_client->send();
+        $response = $this->client->send();
         $this->assertSame(
             $response,
-            $this->_client->getResponse(),
+            $this->client->getResponse(),
             'Response is expected to be identical to the result of getResponse()'
         );
     }
@@ -336,14 +334,14 @@ class StaticTest extends TestCase
     public function testGetLastRawResponseWhenNotStoring()
     {
         // Now, test we get a proper response after the request
-        $this->_client->setUri('http://example.com/foo/bar');
-        $this->_client->setAdapter(Test::class);
-        $this->_client->setOptions(['storeresponse' => false]);
+        $this->client->setUri('http://example.com/foo/bar');
+        $this->client->setAdapter(Test::class);
+        $this->client->setOptions(['storeresponse' => false]);
 
-        $this->_client->send();
+        $this->client->send();
 
         $this->assertNull(
-            $this->_client->getLastRawResponse(),
+            $this->client->getLastRawResponse(),
             'getLastRawResponse is expected to be null when not storing'
         );
     }
@@ -363,11 +361,11 @@ class StaticTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot handle content type \'x-foo/something-fake\' automatically');
 
-        $this->_client->setEncType('x-foo/something-fake');
-        $this->_client->setParameterPost(['parameter' => 'value']);
-        $this->_client->setMethod('POST');
+        $this->client->setEncType('x-foo/something-fake');
+        $this->client->setParameterPost(['parameter' => 'value']);
+        $this->client->setMethod('POST');
         // This should throw an exception
-        $this->_client->send();
+        $this->client->send();
     }
 
     /**
@@ -385,13 +383,13 @@ class StaticTest extends TestCase
         $this->expectExceptionMessage('Unable to connect to 255.255.255.255:80');
 
         // Try to connect to an invalid host
-        $this->_client->setUri('http://255.255.255.255');
+        $this->client->setUri('http://255.255.255.255');
 
         // Reduce timeout to 3 seconds to avoid waiting
-        $this->_client->setOptions(['timeout' => 3]);
+        $this->client->setOptions(['timeout' => 3]);
 
         // This call should cause an exception
-        $this->_client->send();
+        $this->client->send();
     }
 
     /**
@@ -406,7 +404,7 @@ class StaticTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid HTTP method passed');
 
-        $this->_client->setMethod($method);
+        $this->client->setMethod($method);
     }
 
     /**
@@ -421,11 +419,11 @@ class StaticTest extends TestCase
                 HTTPClient::class
             ));
         }
-        $this->_client->setAdapter(Test::class);
-        $this->_client->setUri('http://example.com');
-        $this->_client->setEncType(HTTPClient::ENC_FORMDATA);
+        $this->client->setAdapter(Test::class);
+        $this->client->setUri('http://example.com');
+        $this->client->setEncType(HTTPClient::ENC_FORMDATA);
 
-        $this->_client->setParameterPost([
+        $this->client->setParameterPost([
             'test' => [
                 'v0.1',
                 'v0.2',
@@ -437,12 +435,12 @@ class StaticTest extends TestCase
             ],
         ]);
 
-        $this->_client->setMethod('POST');
-        $this->_client->send();
+        $this->client->setMethod('POST');
+        $this->client->send();
 
         $expectedLines = file(__DIR__ . '/_files/Laminas7038-multipartarrayrequest.txt');
 
-        $gotLines = explode("\n", $this->_client->getLastRawRequest());
+        $gotLines = explode("\n", $this->client->getLastRawRequest());
 
         $this->assertEquals(count($expectedLines), count($gotLines));
 
@@ -473,16 +471,16 @@ class StaticTest extends TestCase
                 HTTPClient::class
             ));
         }
-        $this->_client->setAdapter(Test::class);
-        $this->_client->setUri('http://example.com');
+        $this->client->setAdapter(Test::class);
+        $this->client->setUri('http://example.com');
 
         $bodyFile = __DIR__ . '/_files/Laminas2098-multibytepostdata.txt';
 
-        $this->_client->setRawBody(file_get_contents($bodyFile));
-        $this->_client->setEncType('text/plain');
-        $this->_client->setMethod('POST');
-        $this->_client->send();
-        $request = $this->_client->getLastRawRequest();
+        $this->client->setRawBody(file_get_contents($bodyFile));
+        $this->client->setEncType('text/plain');
+        $this->client->setMethod('POST');
+        $this->client->send();
+        $request = $this->client->getLastRawRequest();
 
         if (! preg_match('/^content-length:\s+(\d+)/mi', $request, $match)) {
             $this->fail('Unable to find content-length header in request');
@@ -585,12 +583,12 @@ class StaticTest extends TestCase
                 HTTPClient::class
             ));
         }
-        $this->_client->addCookie('foo', 'bar=baz');
-        $this->_client->send();
+        $this->client->addCookie('foo', 'bar=baz');
+        $this->client->send();
         $cookieValue = 'Cookie: foo=' . urlencode('bar=baz');
         $this->assertStringContainsString(
             $cookieValue,
-            $this->_client->getLastRawRequest(),
+            $this->client->getLastRawRequest(),
             'Request is expected to contain the entire cookie "keyname=encoded_value"'
         );
     }
@@ -608,13 +606,13 @@ class StaticTest extends TestCase
                 HTTPClient::class
             ));
         }
-        $this->_client->setOptions(['encodecookies' => false]);
-        $this->_client->addCookie('foo', 'bar=baz');
-        $this->_client->send();
+        $this->client->setOptions(['encodecookies' => false]);
+        $this->client->addCookie('foo', 'bar=baz');
+        $this->client->send();
         $cookieValue = 'Cookie: foo=bar=baz';
         $this->assertStringContainsString(
             $cookieValue,
-            $this->_client->getLastRawRequest(),
+            $this->client->getLastRawRequest(),
             'Request is expected to contain the entire cookie "keyname=raw_value"'
         );
     }

--- a/test/Client/TestAdapterTest.php
+++ b/test/Client/TestAdapterTest.php
@@ -1,13 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Client;
 
+use Exception;
 use Laminas\Http\Client\Adapter\Exception\InvalidArgumentException;
 use Laminas\Http\Client\Adapter\Exception\OutOfRangeException;
 use Laminas\Http\Client\Adapter\Exception\RuntimeException;
@@ -119,7 +114,6 @@ class TestAdapterTest extends TestCase
      * Test that responses could be added as strings
      *
      * @dataProvider validHttpResponseProvider
-     *
      * @param string $testResponse
      */
     public function testAddResponseAsString($testResponse)
@@ -187,7 +181,7 @@ class TestAdapterTest extends TestCase
             try {
                 $this->adapter->setResponseIndex($i);
                 $this->fail();
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $this->assertInstanceOf(OutOfRangeException::class, $e);
                 $this->assertMatchesRegularExpression('/out of range/i', $e->getMessage());
             }

--- a/test/Client/TestAsset/MockAdapter.php
+++ b/test/Client/TestAsset/MockAdapter.php
@@ -1,16 +1,11 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Client\TestAsset;
 
 use Laminas\Http\Client\Adapter\Test;
 
 class MockAdapter extends Test
 {
+    /** @var array */
     public $config = [];
 }

--- a/test/Client/TestAsset/MockClient.php
+++ b/test/Client/TestAsset/MockClient.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Client\TestAsset;
 
 use Laminas\Http\Client;
@@ -14,6 +8,7 @@ use Laminas\Http\Request;
 
 class MockClient extends Client
 {
+    /** @var array<string, mixed> */
     public $config = [
         'maxredirects'    => 5,
         'strictredirects' => false,

--- a/test/Client/UseCaseTest.php
+++ b/test/Client/UseCaseTest.php
@@ -1,18 +1,18 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Client;
 
+use Laminas\Http\Client as HTTPClient;
 use Laminas\Http\Client\Adapter\AdapterInterface;
 use Laminas\Http\Client\Adapter\Socket;
-use Laminas\Http\Client as HTTPClient;
 use Laminas\Http\Request;
 use PHPUnit\Framework\TestCase;
+
+use function filter_var;
+use function getenv;
+use function sprintf;
+
+use const FILTER_VALIDATE_BOOLEAN;
 
 /**
  * This are the test for the prototype of Laminas\Http\Client
@@ -58,8 +58,9 @@ class UseCaseTest extends TestCase
      */
     protected function setUp(): void
     {
-        if (getenv('TESTS_LAMINAS_HTTP_CLIENT_BASEURI')
-            && (filter_var(getenv('TESTS_LAMINAS_HTTP_CLIENT_BASEURI'), FILTER_VALIDATE_BOOLEAN) != false)
+        if (
+            getenv('TESTS_LAMINAS_HTTP_CLIENT_BASEURI')
+            && (filter_var(getenv('TESTS_LAMINAS_HTTP_CLIENT_BASEURI'), FILTER_VALIDATE_BOOLEAN) !== false)
         ) {
             $this->baseuri = getenv('TESTS_LAMINAS_HTTP_CLIENT_BASEURI');
             $this->client  = new HTTPClient($this->baseuri);
@@ -95,7 +96,7 @@ class UseCaseTest extends TestCase
 
     public function testRequestHttpGet()
     {
-        $client = new HTTPClient();
+        $client  = new HTTPClient();
         $request = new Request();
         $request->setUri($this->baseuri);
         $request->setMethod(Request::METHOD_GET);

--- a/test/Client/_files/Laminas7683-chunked.php
+++ b/test/Client/_files/Laminas7683-chunked.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 // intentional use of case-insensitive header name
 header('Transfer-encoding: chunked');
 header('content-encoding: gzip');

--- a/test/Client/_files/Laminas9404-doubleContentLength.php
+++ b/test/Client/_files/Laminas9404-doubleContentLength.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 $clength = filesize(__FILE__);
 
 header(sprintf('Content-length: %s', $clength));

--- a/test/Client/_files/fwrite.php
+++ b/test/Client/_files/fwrite.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Http\Client\Adapter;
 
 /**

--- a/test/Client/_files/testConnectTimeout.php
+++ b/test/Client/_files/testConnectTimeout.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 echo 'start';
 sleep(3);
 echo 'end';

--- a/test/Client/_files/testCookies.php
+++ b/test/Client/_files/testCookies.php
@@ -1,9 +1,3 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 echo serialize($_COOKIE);

--- a/test/Client/_files/testCurlGzipData.php
+++ b/test/Client/_files/testCurlGzipData.php
@@ -1,10 +1,4 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 header('Content-Encoding: gzip');
 echo gzcompress('Success');

--- a/test/Client/_files/testDeleteData.php
+++ b/test/Client/_files/testDeleteData.php
@@ -1,9 +1,3 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 readfile("php://input");

--- a/test/Client/_files/testExceptionOnReadTimeout.php
+++ b/test/Client/_files/testExceptionOnReadTimeout.php
@@ -1,14 +1,7 @@
 <?php
 
 /**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
-/**
  * This script does nothing but sleep, and is used to test how
  * Laminas_Http_Client handles an exceeded timeout
  */
-
 sleep(5);

--- a/test/Client/_files/testGetData.php
+++ b/test/Client/_files/testGetData.php
@@ -1,9 +1,3 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 echo serialize($_GET);

--- a/test/Client/_files/testHeadMethod.php
+++ b/test/Client/_files/testHeadMethod.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
-
 $clength = filesize(__FILE__);
 
 header(sprintf('Content-length: %s', $clength));

--- a/test/Client/_files/testHttpAuth.php
+++ b/test/Client/_files/testHttpAuth.php
@@ -1,18 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
-$user = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : null;
-$pass = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : null;
-$guser = isset($_GET['user']) ? $_GET['user'] : null;
-$gpass = isset($_GET['pass']) ? $_GET['pass'] : null;
+$user   = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : null;
+$pass   = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : null;
+$guser  = isset($_GET['user']) ? $_GET['user'] : null;
+$gpass  = isset($_GET['pass']) ? $_GET['pass'] : null;
 $method = isset($_GET['method']) ? $_GET['method'] : 'Basic';
 
-if (! $user || ! $pass || $user != $guser || $pass != $gpass) {
+if (! $user || ! $pass || $user !== $guser || $pass !== $gpass) {
     header('WWW-Authenticate: ' . $method . ' realm="LaminasTest"');
     header('HTTP/1.0 401 Unauthorized');
 }

--- a/test/Client/_files/testMultibyteChunkedResponseLaminas6218.php
+++ b/test/Client/_files/testMultibyteChunkedResponseLaminas6218.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 header("Content-type: text/plain; charset=UTF-8");
 @ob_end_flush();
 @ob_implicit_flush(true);

--- a/test/Client/_files/testOptionsData.php
+++ b/test/Client/_files/testOptionsData.php
@@ -1,9 +1,3 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 readfile("php://input");

--- a/test/Client/_files/testPatchData.php
+++ b/test/Client/_files/testPatchData.php
@@ -1,9 +1,3 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 readfile("php://input");

--- a/test/Client/_files/testPostData.php
+++ b/test/Client/_files/testPostData.php
@@ -1,9 +1,3 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 echo serialize($_POST);

--- a/test/Client/_files/testRawGetData.php
+++ b/test/Client/_files/testRawGetData.php
@@ -1,10 +1,4 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 echo serialize($_GET);
 readfile('php://input');

--- a/test/Client/_files/testRawPostData.php
+++ b/test/Client/_files/testRawPostData.php
@@ -1,9 +1,3 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 readfile('php://input');

--- a/test/Client/_files/testRedirections.php
+++ b/test/Client/_files/testRedirections.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 if (! isset($_GET['redirection'])) {
     $_GET['redirection'] = 0;
 
@@ -26,10 +20,10 @@ if (! isset($_GET['redirection'])) {
 }
 
 $_GET['redirection']++;
-$https = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off';
+$https = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
 
 if (! isset($_GET['redirection']) || $_GET['redirection'] < 4) {
-    $target = 'http' . ($https ? 's://' : '://')  . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'];
+    $target = 'http' . ($https ? 's://' : '://') . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'];
     header('Location: ' . $target . '?redirection=' . $_GET['redirection']);
 } else {
     var_dump($_GET);

--- a/test/Client/_files/testRelativeRedirections.php
+++ b/test/Client/_files/testRelativeRedirections.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 if (! isset($_GET['redirect'])) {
     $_GET['redirect'] = null;
 }

--- a/test/Client/_files/testResetParameters.php
+++ b/test/Client/_files/testResetParameters.php
@@ -1,9 +1,3 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 echo serialize($_GET) . "\n" . serialize($_POST);

--- a/test/Client/_files/testStreamRequest.php
+++ b/test/Client/_files/testStreamRequest.php
@@ -1,9 +1,3 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 readfile('php://input');

--- a/test/Client/_files/testTimeout.php
+++ b/test/Client/_files/testTimeout.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 sleep(2);
 
 echo 'done.';

--- a/test/Client/_files/testUploads.php
+++ b/test/Client/_files/testUploads.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 if (! empty($_FILES)) {
     foreach ($_FILES as $name => $file) {
         if (is_array($file['name'])) {

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -1,10 +1,4 @@
-<?php
-
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
+<?php // phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCaps
 
 namespace LaminasTest\Http;
 
@@ -28,6 +22,16 @@ use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use ReflectionProperty;
 
+use function base64_encode;
+use function count;
+use function file_get_contents;
+use function ini_get;
+use function ini_set;
+use function json_encode;
+use function strlen;
+use function sys_get_temp_dir;
+use function tempnam;
+
 class ClientTest extends TestCase
 {
     public function testIfCookiesAreSticky()
@@ -44,13 +48,13 @@ class ClientTest extends TestCase
             . 'Accept-Language: en-US,en;q=0.5' . "\r\n"
             . 'Accept-Encoding: gzip, deflate' . "\r\n"
             . 'Connection: keep-alive' . "\r\n";
-        $request = Request::fromString($requestString);
+        $request       = Request::fromString($requestString);
 
         $client = new Client('http://www.domain.com/');
         $client->setRequest($request);
         $client->addCookie($initialCookies);
 
-        $cookies = new Cookies($client->getRequest()->getHeaders());
+        $cookies    = new Cookies($client->getRequest()->getHeaders());
         $rawHeaders = 'HTTP/1.1 200 OK' . "\r\n"
             . 'Access-Control-Allow-Origin: *' . "\r\n"
             . 'Content-Encoding: gzip' . "\r\n"
@@ -62,7 +66,7 @@ class ClientTest extends TestCase
             . 'Vary: Accept-Encoding' . "\r\n"
             . 'X-Powered-By: PHP/5.3.10-1ubuntu3.4' . "\r\n"
             . 'Connection: keep-alive' . "\r\n";
-        $response = Response::fromString($rawHeaders);
+        $response   = Response::fromString($rawHeaders);
         $client->setResponse($response);
 
         $cookies->addCookiesFromResponse($client->getResponse(), $client->getUri());
@@ -91,7 +95,7 @@ class ClientTest extends TestCase
             . 'Accept-Language: en-US,en;q=0.5' . "\r\n"
             . 'Accept-Encoding: gzip, deflate' . "\r\n"
             . 'Connection: keep-alive' . "\r\n";
-        $request = Request::fromString($requestString);
+        $request       = Request::fromString($requestString);
 
         $adapter = new Test();
 
@@ -108,7 +112,7 @@ class ClientTest extends TestCase
             . 'Vary: Accept-Encoding' . "\r\n"
             . 'X-Powered-By: PHP/5.3.10-1ubuntu3.4' . "\r\n"
             . 'Connection: keep-alive' . "\r\n";
-        $response = Response::fromString($rawHeaders);
+        $response   = Response::fromString($rawHeaders);
         $client->getAdapter()->setResponse($response);
 
         $headers = $method->invoke($client, $requestString, $client->getUri());
@@ -177,7 +181,7 @@ class ClientTest extends TestCase
     public function testArgSeparatorDefaultsToIniSetting()
     {
         $argSeparator = ini_get('arg_separator.output');
-        $client = new Client();
+        $client       = new Client();
         $this->assertEquals($argSeparator, $client->getArgSeparator());
     }
 
@@ -255,8 +259,8 @@ class ClientTest extends TestCase
 
         // create a client which allows one redirect at most!
         $client = new Client('http://www.example.org/part1', [
-            'adapter' => $testAdapter,
-            'maxredirects' => 1,
+            'adapter'       => $testAdapter,
+            'maxredirects'  => 1,
             'storeresponse' => true,
         ]);
 
@@ -271,9 +275,9 @@ class ClientTest extends TestCase
     public function testIfClientDoesNotLooseAuthenticationOnRedirect()
     {
         // set up user credentials
-        $user = 'username123';
+        $user     = 'username123';
         $password = 'password456';
-        $encoded = Client::encodeAuthHeader($user, $password, Client::AUTH_BASIC);
+        $encoded  = Client::encodeAuthHeader($user, $password, Client::AUTH_BASIC);
 
         // set up two responses that simulate a redirection
         $testAdapter = new Test();
@@ -289,7 +293,7 @@ class ClientTest extends TestCase
 
         // create client with HTTP basic authentication
         $client = new Client('http://www.example.org/part1', [
-            'adapter' => $testAdapter,
+            'adapter'      => $testAdapter,
             'maxredirects' => 1,
         ]);
         $client->setAuth($user, $password, Client::AUTH_BASIC);
@@ -304,12 +308,12 @@ class ClientTest extends TestCase
     public function testIfClientDoesNotForwardAuthenticationToForeignHost()
     {
         // set up user credentials
-        $user = 'username123';
+        $user     = 'username123';
         $password = 'password456';
-        $encoded = Client::encodeAuthHeader($user, $password, Client::AUTH_BASIC);
+        $encoded  = Client::encodeAuthHeader($user, $password, Client::AUTH_BASIC);
 
         $testAdapter = new Test();
-        $client = new Client(null, ['adapter' => $testAdapter]);
+        $client      = new Client(null, ['adapter' => $testAdapter]);
 
         // set up two responses that simulate a redirection from example.org to example.com
         $testAdapter->setResponse(
@@ -375,7 +379,7 @@ class ClientTest extends TestCase
     public function testAdapterAlwaysReachableIfSpecified()
     {
         $testAdapter = new Test();
-        $client = new Client('http://www.example.org/', [
+        $client      = new Client('http://www.example.org/', [
             'adapter' => $testAdapter,
         ]);
 
@@ -386,7 +390,7 @@ class ClientTest extends TestCase
     {
         $body = json_encode(['foofoo' => 'barbar']);
 
-        $client = new Client();
+        $client                   = new Client();
         $prepareHeadersReflection = new ReflectionMethod($client, 'prepareHeaders');
         $prepareHeadersReflection->setAccessible(true);
 
@@ -412,7 +416,7 @@ class ClientTest extends TestCase
     {
         $body = json_encode(['foofoo' => 'barbar']);
 
-        $client = new Client();
+        $client                   = new Client();
         $prepareHeadersReflection = new ReflectionMethod($client, 'prepareHeaders');
         $prepareHeadersReflection->setAccessible(true);
 
@@ -533,10 +537,11 @@ class ClientTest extends TestCase
         $this->assertStringContainsString('foo=bar&baz=foo', $rawRequest);
     }
 
-    public function uriDataProvider()
+    /** @psalm-return array<string, array{0: string, 1: bool}> */
+    public function uriDataProvider(): array
     {
         return [
-            'valid-relative' => ['/example', true],
+            'valid-relative'   => ['/example', true],
             'invalid-absolute' => ['http://localhost/example', false],
         ];
     }
@@ -544,8 +549,10 @@ class ClientTest extends TestCase
     /**
      * @dataProvider uriDataProvider
      */
-    public function testUriCorrectlyDeterminesWhetherOrNotItIsAValidRelativeUri($uri, $isValidRelativeURI)
-    {
+    public function testUriCorrectlyDeterminesWhetherOrNotItIsAValidRelativeUri(
+        string $uri,
+        bool $isValidRelativeURI
+    ): void {
         $client = new Client($uri);
         $this->assertSame($isValidRelativeURI, $client->getUri()->isValidRelative());
 
@@ -554,19 +561,22 @@ class ClientTest extends TestCase
         $this->assertSame($isValidRelativeURI, $client->getUri()->isValidRelative());
     }
 
-    public function portChangeDataProvider()
+    /** @psalm-return array<string, array{0: string, 1: int}> */
+    public function portChangeDataProvider(): array
     {
         return [
             'default-https' => ['https://localhost/example', 443],
-            'default-http' => ['http://localhost/example', 80]
+            'default-http'  => ['http://localhost/example', 80],
         ];
     }
 
     /**
      * @dataProvider portChangeDataProvider
      */
-    public function testUriPortIsSetToAppropriateDefaultValueWhenAnUriOmittingThePortIsProvided($absoluteURI, $port)
-    {
+    public function testUriPortIsSetToAppropriateDefaultValueWhenAnUriOmittingThePortIsProvided(
+        string $absoluteURI,
+        int $port
+    ): void {
         $client = new Client();
         $client->getUri()->setPort(null);
 
@@ -588,13 +598,15 @@ class ClientTest extends TestCase
         $this->assertNull($client->getUri()->getPort());
     }
 
-    public function cookies()
+    /** @psalm-return iterable<string, array{0: array<string, string>|SetCookie[]}> */
+    public function cookies(): iterable
     {
         yield 'name-value' => [['cookie-name' => 'cookie-value']];
         yield 'SetCookie' => [[new SetCookie('cookie-name', 'cookie-value')]];
     }
 
     /**
+     * phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
      * @dataProvider cookies
      */
     public function testSetCookies(array $cookies)

--- a/test/CookiesTest.php
+++ b/test/CookiesTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http;
 
 use Laminas\Http\Cookies;
@@ -20,8 +14,8 @@ class CookiesTest extends TestCase
     public function testFromResponseInSetCookie()
     {
         $response = new Response();
-        $headers = new Headers();
-        $header = new SetCookie('foo', 'bar');
+        $headers  = new Headers();
+        $header   = new SetCookie('foo', 'bar');
         $header->setDomain('www.zend.com');
         $header->setPath('/');
         $headers->addHeader($header);
@@ -34,8 +28,8 @@ class CookiesTest extends TestCase
     public function testFromResponseInCookie()
     {
         $response = new Response();
-        $headers = new Headers();
-        $header = new SetCookie('foo', 'bar');
+        $headers  = new Headers();
+        $header   = new SetCookie('foo', 'bar');
         $header->setDomain('www.zend.com');
         $header->setPath('/');
         $headers->addHeader($header);
@@ -47,17 +41,17 @@ class CookiesTest extends TestCase
 
     public function testRequestCanHaveArrayCookies()
     {
-        $_COOKIE = [
+        $_COOKIE    = [
             'test' => [
                 'a' => 'value_a',
                 'b' => 'value_b',
             ],
         ];
-        $request = new Request();
+        $request    = new Request();
         $fieldValue = $request->getCookie('test')->getFieldValue();
         $this->assertSame('test[a]=value_a; test[b]=value_b', $fieldValue);
 
-        $_COOKIE = [
+        $_COOKIE    = [
             'test' => [
                 'a' => [
                     'a1' => 'va1',
@@ -69,7 +63,7 @@ class CookiesTest extends TestCase
                 ],
             ],
         ];
-        $request = new Request();
+        $request    = new Request();
         $fieldValue = $request->getCookie('test')->getFieldValue();
         $this->assertSame('test[a][a1]=va1; test[a][a2]=va2; test[b][b1]=vb1; test[b][b2]=vb2', $fieldValue);
     }

--- a/test/Header/AcceptCharsetTest.php
+++ b/test/Header/AcceptCharsetTest.php
@@ -1,17 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\AcceptCharset;
 use Laminas\Http\Header\Exception\InvalidArgumentException;
 use Laminas\Http\Header\HeaderInterface;
 use PHPUnit\Framework\TestCase;
+
+use function array_shift;
 
 class AcceptCharsetTest extends TestCase
 {
@@ -55,8 +51,9 @@ class AcceptCharsetTest extends TestCase
         $this->assertEquals('Accept-Charset: iso-8859-5;q=0.8, unicode-1-1', $acceptCharsetHeader->toString());
     }
 
-    /** Implementation specific tests here */
+    // Implementation specific tests here
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testCanParseCommaSeparatedValues()
     {
         $header = AcceptCharset::fromString('Accept-Charset: iso-8859-5;q=0.8,unicode-1-1');
@@ -91,6 +88,7 @@ class AcceptCharsetTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -101,6 +99,7 @@ class AcceptCharsetTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaSetters()

--- a/test/Header/AcceptEncodingTest.php
+++ b/test/Header/AcceptEncodingTest.php
@@ -1,17 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\AcceptEncoding;
 use Laminas\Http\Header\Exception\InvalidArgumentException;
 use Laminas\Http\Header\HeaderInterface;
 use PHPUnit\Framework\TestCase;
+
+use function array_shift;
 
 class AcceptEncodingTest extends TestCase
 {
@@ -55,8 +51,9 @@ class AcceptEncodingTest extends TestCase
         $this->assertEquals('Accept-Encoding: compress;q=0.5, gzip', $acceptEncodingHeader->toString());
     }
 
-    /** Implementation specific tests here */
+    // Implementation specific tests here
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testCanParseCommaSeparatedValues()
     {
         $header = AcceptEncoding::fromString('Accept-Encoding: compress;q=0.5,gzip');
@@ -92,6 +89,7 @@ class AcceptEncodingTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -102,6 +100,7 @@ class AcceptEncodingTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaSetters()

--- a/test/Header/AcceptLanguageTest.php
+++ b/test/Header/AcceptLanguageTest.php
@@ -1,17 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\AcceptLanguage;
 use Laminas\Http\Header\Exception\InvalidArgumentException;
 use Laminas\Http\Header\HeaderInterface;
 use PHPUnit\Framework\TestCase;
+
+use function array_shift;
 
 class AcceptLanguageTest extends TestCase
 {
@@ -55,8 +51,9 @@ class AcceptLanguageTest extends TestCase
         $this->assertEquals('Accept-Language: da;q=0.8, en-gb', $acceptLanguageHeader->toString());
     }
 
-    /** Implementation specific tests here */
+    // Implementation specific tests here
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testCanParseCommaSeparatedValues()
     {
         $header = AcceptLanguage::fromString('Accept-Language: da;q=0.8, en-gb');
@@ -94,7 +91,7 @@ class AcceptLanguageTest extends TestCase
     public function testWildcards()
     {
         $accept = AcceptLanguage::fromString('*, en-*, en-us');
-        $res = $accept->getPrioritized();
+        $res    = $accept->getPrioritized();
 
         $this->assertEquals('en-us', $res[0]->getLanguage());
         $this->assertEquals('en', $res[0]->getPrimaryTag());
@@ -108,6 +105,7 @@ class AcceptLanguageTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -118,6 +116,7 @@ class AcceptLanguageTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaSetters()

--- a/test/Header/AcceptRangesTest.php
+++ b/test/Header/AcceptRangesTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\AcceptRanges;
@@ -48,6 +42,7 @@ class AcceptRangesTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -58,6 +53,7 @@ class AcceptRangesTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/AcceptTest.php
+++ b/test/Header/AcceptTest.php
@@ -130,12 +130,12 @@ class AcceptTest extends TestCase
     {
         $values = [
             'invalidPrio' => false,
-            -0.0001       => false,
-            1.0001        => false,
-            1.000         => true,
-            0.999         => true,
-            0.000         => true,
-            0.001         => true,
+            '-0.0001'     => false,
+            '1.0001'      => false,
+            '1.000'       => true,
+            '0.999'       => true,
+            '0.000'       => true,
+            '0.001'       => true,
             1             => true,
             0             => true,
         ];

--- a/test/Header/AcceptTest.php
+++ b/test/Header/AcceptTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Accept;
@@ -14,6 +8,9 @@ use Laminas\Http\Header\Accept\FieldValuePart\AcceptFieldValuePart;
 use Laminas\Http\Header\Exception\InvalidArgumentException;
 use Laminas\Http\Header\HeaderInterface;
 use PHPUnit\Framework\TestCase;
+
+use function addslashes;
+use function array_shift;
 
 class AcceptTest extends TestCase
 {
@@ -65,8 +62,9 @@ class AcceptTest extends TestCase
         $acceptHeader->addMediaType('\\', 0.9);
     }
 
-    /** Implementation specific tests here */
+    // Implementation specific tests here
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testCanParseCommaSeparatedValues()
     {
         $header = Accept::fromString('Accept: text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c');
@@ -192,7 +190,7 @@ class AcceptTest extends TestCase
 
     public function testParsingAndAssemblingQuotedStrings()
     {
-        $acceptStr = 'Accept: application/vnd.foobar+html;q=1;version="2'
+        $acceptStr    = 'Accept: application/vnd.foobar+html;q=1;version="2'
                    . '\"";level="foo;, bar", text/json;level=1, text/xml;level=2;q=0.4';
         $acceptHeader = Accept::fromString($acceptStr);
 
@@ -201,7 +199,7 @@ class AcceptTest extends TestCase
 
     public function testMatchReturnsMatchedAgainstObject()
     {
-        $acceptStr = 'Accept: text/html;q=1; version=23; level=5, text/json;level=1,text/xml;level=2;q=0.4';
+        $acceptStr    = 'Accept: text/html;q=1; version=23; level=5, text/json;level=1,text/xml;level=2;q=0.4';
         $acceptHeader = Accept::fromString($acceptStr);
 
         $res = $acceptHeader->match('text/html; _randomValue=foobar');
@@ -211,7 +209,7 @@ class AcceptTest extends TestCase
             $res->getMatchedAgainst()->getParams()->_randomValue
         );
 
-        $acceptStr = 'Accept: */*; ';
+        $acceptStr    = 'Accept: */*; ';
         $acceptHeader = Accept::fromString($acceptStr);
 
         $res = $acceptHeader->match('text/html; _foo=bar');
@@ -225,7 +223,7 @@ class AcceptTest extends TestCase
 
     public function testVersioning()
     {
-        $acceptStr = 'Accept: text/html;q=1; version=23; level=5, text/json;level=1,text/xml;level=2;q=0.4';
+        $acceptStr    = 'Accept: text/html;q=1; version=23; level=5, text/json;level=1,text/xml;level=2;q=0.4';
         $acceptHeader = Accept::fromString($acceptStr);
 
         $expected = [
@@ -273,7 +271,7 @@ class AcceptTest extends TestCase
         $this->assertFalse($acceptHeader->match('*/*; version=20-22'));
 
         $acceptHeader = Accept::fromString('Accept: */*; version=21');
-        $res = $acceptHeader->match('*/*; version=20-22');
+        $res          = $acceptHeader->match('*/*; version=20-22');
         $this->assertInstanceOf(AcceptFieldValuePart::class, $res);
         $this->assertEquals('21', $res->getParams()->version);
     }
@@ -292,9 +290,7 @@ class AcceptTest extends TestCase
      * @group 3740
      * @covers Laminas\Http\Header\AbstractAccept::matchAcceptParams()
      * @covers Laminas\Http\Header\AbstractAccept::getParametersFromFieldValuePart()
-     *
      * @dataProvider provideParamRanges
-     *
      * @param string $range
      * @param string $input
      * @param bool $success
@@ -338,7 +334,7 @@ class AcceptTest extends TestCase
 
     public function testVersioningAndPriorization()
     {
-        $acceptStr = 'Accept: text/html; version=23, text/json; version=15.3; q=0.9,text/html;level=2;q=0.4';
+        $acceptStr    = 'Accept: text/html; version=23, text/json; version=15.3; q=0.9,text/html;level=2;q=0.4';
         $acceptHeader = Accept::fromString($acceptStr);
 
         $expected = [
@@ -407,27 +403,27 @@ class AcceptTest extends TestCase
     public function testPrioritizing2()
     {
         $accept = Accept::fromString("Accept: application/text, \tapplication/*");
-        $res = $accept->getPrioritized();
+        $res    = $accept->getPrioritized();
         $this->assertEquals('application/text', $res[0]->raw);
         $this->assertEquals('application/*', $res[1]->raw);
 
         $accept = Accept::fromString("Accept: \tapplication/*, application/text");
-        $res = $accept->getPrioritized();
+        $res    = $accept->getPrioritized();
         $this->assertEquals('application/text', $res[0]->raw);
         $this->assertEquals('application/*', $res[1]->raw);
 
         $accept = Accept::fromString('Accept: text/xml, application/xml');
-        $res = $accept->getPrioritized();
+        $res    = $accept->getPrioritized();
         $this->assertEquals('application/xml', $res[0]->raw);
         $this->assertEquals('text/xml', $res[1]->raw);
 
         $accept = Accept::fromString('Accept: application/xml, text/xml');
-        $res = $accept->getPrioritized();
+        $res    = $accept->getPrioritized();
         $this->assertEquals('application/xml', $res[0]->raw);
         $this->assertEquals('text/xml', $res[1]->raw);
 
         $accept = Accept::fromString('Accept: application/vnd.foobar+xml; q=0.9, text/xml');
-        $res = $accept->getPrioritized();
+        $res    = $accept->getPrioritized();
         $this->assertEquals(1.0, $res[0]->getPriority());
         $this->assertEquals(0.9, $res[1]->getPriority());
         $this->assertEquals('application/vnd.foobar+xml', $res[1]->getTypeString());
@@ -436,7 +432,7 @@ class AcceptTest extends TestCase
         $this->assertEquals('xml', $res[1]->getFormat());
 
         $accept = Accept::fromString('Accept: text/xml, application/vnd.foobar+xml; version="\'Ѿ"');
-        $res = $accept->getPrioritized();
+        $res    = $accept->getPrioritized();
         $this->assertEquals('application/vnd.foobar+xml; version="\'Ѿ"', $res[0]->getRaw());
     }
 
@@ -461,6 +457,7 @@ class AcceptTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()

--- a/test/Header/AgeTest.php
+++ b/test/Header/AgeTest.php
@@ -1,17 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Age;
 use Laminas\Http\Header\Exception\InvalidArgumentException;
 use Laminas\Http\Header\HeaderInterface;
 use PHPUnit\Framework\TestCase;
+
+use const PHP_INT_MAX;
 
 class AgeTest extends TestCase
 {
@@ -52,6 +48,7 @@ class AgeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -62,6 +59,7 @@ class AgeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/AllowTest.php
+++ b/test/Header/AllowTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Allow;
@@ -43,7 +37,7 @@ class AllowTest extends TestCase
 
     public function testAllowListAllDefinedMethods()
     {
-        $methods = [
+        $methods     = [
             'OPTIONS' => false,
             'GET'     => true,
             'HEAD'    => false,
@@ -87,6 +81,7 @@ class AllowTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -97,20 +92,20 @@ class AllowTest extends TestCase
         Allow::fromString("Allow: GET\r\n\r\nevilContent");
     }
 
-    public function injectionMethods()
+    /** @psalm-return array<string, array{0: string|string[]}> */
+    public function injectionMethods(): array
     {
         return [
             'string' => ["\rG\r\nE\nT"],
-            'array' => [["\rG\r\nE\nT"]],
+            'array'  => [["\rG\r\nE\nT"]],
         ];
     }
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
-     *
      * @dataProvider injectionMethods
-     *
      * @param array|string $methods
      */
     public function testPreventsCRLFAttackViaAllowMethods($methods)
@@ -124,10 +119,9 @@ class AllowTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
-     *
      * @dataProvider injectionMethods
-     *
      * @param array|string $methods
      */
     public function testPreventsCRLFAttackViaDisallowMethods($methods)

--- a/test/Header/AuthenticationInfoTest.php
+++ b/test/Header/AuthenticationInfoTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\AuthenticationInfo;
@@ -50,6 +44,7 @@ class AuthenticationInfoTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class AuthenticationInfoTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/AuthorizationTest.php
+++ b/test/Header/AuthorizationTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Authorization;
@@ -47,6 +41,7 @@ class AuthorizationTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -57,6 +52,7 @@ class AuthorizationTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/CacheControlTest.php
+++ b/test/Header/CacheControlTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\CacheControl;
@@ -46,8 +40,9 @@ class CacheControlTest extends TestCase
         $this->assertEmpty('Cache-Control: xxx', $cacheControlHeader->toString());
     }
 
-    /** Implementation specific tests here */
+    // Implementation specific tests here
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testCacheControlIsEmpty()
     {
         $cacheControlHeader = new CacheControl();
@@ -103,6 +98,7 @@ class CacheControlTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -113,6 +109,7 @@ class CacheControlTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testProtectsFromCRLFAttackViaSetters()

--- a/test/Header/ConnectionTest.php
+++ b/test/Header/ConnectionTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Connection;
@@ -57,6 +51,7 @@ class ConnectionTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -67,6 +62,7 @@ class ConnectionTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaSetters()

--- a/test/Header/ContentDispositionTest.php
+++ b/test/Header/ContentDispositionTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\ContentDisposition;
@@ -50,6 +44,7 @@ class ContentDispositionTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ContentDispositionTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ContentEncodingTest.php
+++ b/test/Header/ContentEncodingTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\ContentEncoding;
@@ -50,6 +44,7 @@ class ContentEncodingTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ContentEncodingTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ContentLanguageTest.php
+++ b/test/Header/ContentLanguageTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\ContentLanguage;
@@ -50,6 +44,7 @@ class ContentLanguageTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ContentLanguageTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ContentLengthTest.php
+++ b/test/Header/ContentLengthTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\ContentLength;
@@ -50,6 +44,7 @@ class ContentLengthTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ContentLengthTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ContentLocationTest.php
+++ b/test/Header/ContentLocationTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\ContentLocation;
@@ -41,12 +35,13 @@ class ContentLocationTest extends TestCase
         $this->assertEquals('Content-Location: http://www.example.com/path?query', $contentLocationHeader->toString());
     }
 
-    /** Implementation specific tests here */
+    // Implementation specific tests here
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testContentLocationCanSetAndAccessAbsoluteUri()
     {
         $contentLocationHeader = ContentLocation::fromString('Content-Location: http://www.example.com/path');
-        $uri = $contentLocationHeader->uri();
+        $uri                   = $contentLocationHeader->uri();
         $this->assertInstanceOf(UriInterface::class, $uri);
         $this->assertTrue($uri->isAbsolute());
         $this->assertEquals('http://www.example.com/path', $contentLocationHeader->getUri());
@@ -55,7 +50,7 @@ class ContentLocationTest extends TestCase
     public function testContentLocationCanSetAndAccessRelativeUri()
     {
         $contentLocationHeader = ContentLocation::fromString('Content-Location: /path/to');
-        $uri = $contentLocationHeader->uri();
+        $uri                   = $contentLocationHeader->uri();
         $this->assertInstanceOf(UriInterface::class, $uri);
         $this->assertFalse($uri->isAbsolute());
         $this->assertEquals('/path/to', $contentLocationHeader->getUri());
@@ -63,6 +58,7 @@ class ContentLocationTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()

--- a/test/Header/ContentMD5Test.php
+++ b/test/Header/ContentMD5Test.php
@@ -1,10 +1,4 @@
-<?php
-
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
+<?php // phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCaps
 
 namespace LaminasTest\Http\Header;
 
@@ -50,6 +44,7 @@ class ContentMD5Test extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ContentMD5Test extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ContentRangeTest.php
+++ b/test/Header/ContentRangeTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\ContentRange;
@@ -50,6 +44,7 @@ class ContentRangeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ContentRangeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ContentSecurityPolicyReportOnlyTest.php
+++ b/test/Header/ContentSecurityPolicyReportOnlyTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\ContentSecurityPolicyReportOnly;

--- a/test/Header/ContentSecurityPolicyTest.php
+++ b/test/Header/ContentSecurityPolicyTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Exception\RuntimeException;
@@ -16,6 +10,8 @@ use Laminas\Http\Header\HeaderInterface;
 use Laminas\Http\Header\MultipleHeaderInterface;
 use Laminas\Http\Headers;
 use PHPUnit\Framework\TestCase;
+
+use function implode;
 
 class ContentSecurityPolicyTest extends TestCase
 {
@@ -101,6 +97,7 @@ class ContentSecurityPolicyTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -111,6 +108,7 @@ class ContentSecurityPolicyTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaDirective()
@@ -189,10 +187,11 @@ class ContentSecurityPolicyTest extends TestCase
         );
     }
 
-    public static function validDirectives()
+    /** @psalm-return array<array-key, array{0: string, 1: string[], 2: string}> */
+    public static function validDirectives(): array
     {
         return [
-            ['child-src', ["'self'"],"Content-Security-Policy: child-src 'self';"],
+            ['child-src', ["'self'"], "Content-Security-Policy: child-src 'self';"],
             ['manifest-src', ["'self'"], "Content-Security-Policy: manifest-src 'self';"],
             ['worker-src', ["'self'"], "Content-Security-Policy: worker-src 'self';"],
             ['prefetch-src', ["'self'"], "Content-Security-Policy: prefetch-src 'self';"],
@@ -205,12 +204,12 @@ class ContentSecurityPolicyTest extends TestCase
             [
                 'form-action',
                 ['http://*.example.com', "'self'"],
-                "Content-Security-Policy: form-action http://*.example.com 'self';"
+                "Content-Security-Policy: form-action http://*.example.com 'self';",
             ],
             [
                 'frame-ancestors',
                 ['http://*.example.com', "'self'"],
-                "Content-Security-Policy: frame-ancestors http://*.example.com 'self';"
+                "Content-Security-Policy: frame-ancestors http://*.example.com 'self';",
             ],
             ['navigate-to', ['example.com'], 'Content-Security-Policy: navigate-to example.com;'],
             ['sandbox', ['allow-forms'], 'Content-Security-Policy: sandbox allow-forms;'],
@@ -225,7 +224,6 @@ class ContentSecurityPolicyTest extends TestCase
 
     /**
      * @dataProvider validDirectives
-     *
      * @param string $directive
      * @param string[] $values
      * @param string $expected
@@ -243,7 +241,6 @@ class ContentSecurityPolicyTest extends TestCase
 
     /**
      * @dataProvider validDirectives
-     *
      * @param string $directive
      * @param string[] $values
      * @param string $header
@@ -267,7 +264,6 @@ class ContentSecurityPolicyTest extends TestCase
 
     /**
      * @dataProvider directivesWithoutValue
-     *
      * @param string $directive
      */
     public function testExceptionWhenProvideValueWithDirectiveWithoutValue($directive)

--- a/test/Header/ContentTransferEncodingTest.php
+++ b/test/Header/ContentTransferEncodingTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\ContentTransferEncoding;
@@ -50,6 +44,7 @@ class ContentTransferEncodingTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ContentTransferEncodingTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ContentTypeTest.php
+++ b/test/Header/ContentTypeTest.php
@@ -1,17 +1,14 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\ContentType;
 use Laminas\Http\Header\Exception\InvalidArgumentException;
 use Laminas\Http\Header\HeaderInterface;
 use PHPUnit\Framework\TestCase;
+
+use function implode;
+use function strtolower;
 
 class ContentTypeTest extends TestCase
 {
@@ -43,29 +40,29 @@ class ContentTypeTest extends TestCase
         $this->assertEquals('Content-Type: application/atom+xml; charset=ISO-8859-1', $header->toString());
     }
 
-    /** Implementation specific tests here */
+    // Implementation specific tests here
 
-    public function wildcardMatches()
+    /** @psalm-return array<string, array{0: string}> */
+    public function wildcardMatches(): array
     {
         return [
-            'wildcard' => ['*/*'],
-            'wildcard-format' => ['*/*+*'],
-            'wildcard-type-subtype-fixed-format' => ['*/*+json'],
+            'wildcard'                                            => ['*/*'],
+            'wildcard-format'                                     => ['*/*+*'],
+            'wildcard-type-subtype-fixed-format'                  => ['*/*+json'],
             'wildcard-type-partial-wildcard-subtype-fixed-format' => ['*/vnd.*+json'],
-            'wildcard-type-format-subtype' => ['*/json'],
-            'fixed-type-wildcard-subtype' => ['application/*'],
-            'fixed-type-wildcard-subtype-fixed-format' => ['application/*+json'],
-            'fixed-type-format-subtype' => ['application/json'],
-            'fixed-type-fixed-subtype-wildcard-format' => ['application/vnd.foobar+*'],
-            'fixed-type-partial-wildcard-subtype-fixed-format' => ['application/vnd.*+json'],
-            'fixed' => ['application/vnd.foobar+json'],
-            'fixed-mixed-case' => ['APPLICATION/vnd.FooBar+json'],
+            'wildcard-type-format-subtype'                        => ['*/json'],
+            'fixed-type-wildcard-subtype'                         => ['application/*'],
+            'fixed-type-wildcard-subtype-fixed-format'            => ['application/*+json'],
+            'fixed-type-format-subtype'                           => ['application/json'],
+            'fixed-type-fixed-subtype-wildcard-format'            => ['application/vnd.foobar+*'],
+            'fixed-type-partial-wildcard-subtype-fixed-format'    => ['application/vnd.*+json'],
+            'fixed'                                               => ['application/vnd.foobar+json'],
+            'fixed-mixed-case'                                    => ['APPLICATION/vnd.FooBar+json'],
         ];
     }
 
     /**
      * @dataProvider wildcardMatches
-     *
      * @param string $matchAgainst
      */
     public function testMatchWildCard($matchAgainst)
@@ -75,22 +72,22 @@ class ContentTypeTest extends TestCase
         $this->assertEquals(strtolower($matchAgainst), $result);
     }
 
-    public function invalidMatches()
+    /** @psalm-return array<string, array{0: string}> */
+    public function invalidMatches(): array
     {
         return [
-            'format' => ['application/vnd.foobar+xml'],
-            'wildcard-subtype' => ['application/vendor.*+json'],
-            'subtype' => ['application/vendor.foobar+json'],
-            'type' => ['text/vnd.foobar+json'],
-            'wildcard-type-format' => ['*/vnd.foobar+xml'],
+            'format'                         => ['application/vnd.foobar+xml'],
+            'wildcard-subtype'               => ['application/vendor.*+json'],
+            'subtype'                        => ['application/vendor.foobar+json'],
+            'type'                           => ['text/vnd.foobar+json'],
+            'wildcard-type-format'           => ['*/vnd.foobar+xml'],
             'wildcard-type-wildcard-subtype' => ['*/vendor.*+json'],
-            'wildcard-type-subtype' => ['*/vendor.foobar+json'],
+            'wildcard-type-subtype'          => ['*/vendor.foobar+json'],
         ];
     }
 
     /**
      * @dataProvider invalidMatches
-     *
      * @param string $matchAgainst
      */
     public function testFailedMatches($matchAgainst)
@@ -100,7 +97,8 @@ class ContentTypeTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function multipleCriteria()
+    /** @psalm-return array<string, array{0: string|string[]}> */
+    public function multipleCriteria(): array
     {
         $criteria = [
             'application/vnd.foobar+xml',
@@ -109,14 +107,13 @@ class ContentTypeTest extends TestCase
             '*/vnd.foobar+json',
         ];
         return [
-            'array' => [$criteria],
+            'array'  => [$criteria],
             'string' => [implode(',', $criteria)],
         ];
     }
 
     /**
      * @dataProvider multipleCriteria
-     *
      * @param array|string $criteria
      */
     public function testReturnsMatchingMediaTypeOfFirstCriteriaToValidate($criteria)
@@ -126,19 +123,19 @@ class ContentTypeTest extends TestCase
         $this->assertEquals('application/vnd.*+json', $result);
     }
 
-    public function contentTypeParameterExamples()
+    /** @psalm-return array<string, array{0: string, 1: string}> */
+    public function contentTypeParameterExamples(): array
     {
         return [
-            'no-quotes' => ['Content-Type: foo/bar; param=baz', 'baz'],
-            'with-quotes' => ['Content-Type: foo/bar; param="baz"', 'baz'],
-            'with-equals' => ['Content-Type: foo/bar; param=baz=bat', 'baz=bat'],
+            'no-quotes'              => ['Content-Type: foo/bar; param=baz', 'baz'],
+            'with-quotes'            => ['Content-Type: foo/bar; param="baz"', 'baz'],
+            'with-equals'            => ['Content-Type: foo/bar; param=baz=bat', 'baz=bat'],
             'with-equals-and-quotes' => ['Content-Type: foo/bar; param="baz=bat"', 'baz=bat'],
         ];
     }
 
     /**
      * @dataProvider contentTypeParameterExamples
-     *
      * @param string $headerString
      * @param string $expectedParameterValue
      */
@@ -154,6 +151,7 @@ class ContentTypeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -164,6 +162,7 @@ class ContentTypeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/CookieTest.php
+++ b/test/Header/CookieTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use ArrayObject;
@@ -57,7 +51,7 @@ class CookieTest extends TestCase
 
     public function testCookieGetFieldValueReturnsProperValue()
     {
-        $cookieHeader = new Cookie();
+        $cookieHeader      = new Cookie();
         $cookieHeader->foo = 'bar';
         $this->assertEquals('foo=bar', $cookieHeader->getFieldValue());
     }
@@ -72,6 +66,7 @@ class CookieTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -82,10 +77,9 @@ class CookieTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
-     *
      * @dataProvider valuesProvider
-     *
      * @param mixed $value
      * @param string $serialized
      */
@@ -95,7 +89,8 @@ class CookieTest extends TestCase
         $this->assertEquals('Cookie: ' . $serialized, $header->toString());
     }
 
-    public function valuesProvider()
+    /** @psalm-return array<string, array{0:string, 1: string}> */
+    public function valuesProvider(): array
     {
         return [
             // Description => [raw value, serialized]

--- a/test/Header/DateTest.php
+++ b/test/Header/DateTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use DateTime;
@@ -14,6 +8,10 @@ use Laminas\Http\Header\Date;
 use Laminas\Http\Header\Exception\InvalidArgumentException;
 use Laminas\Http\Header\HeaderInterface;
 use PHPUnit\Framework\TestCase;
+
+use function time;
+
+use const PHP_VERSION_ID;
 
 class DateTest extends TestCase
 {
@@ -100,8 +98,9 @@ class DateTest extends TestCase
         $this->assertEquals('Date: Sun, 06 Nov 1994 08:49:37 GMT', $dateHeader->toString());
     }
 
-    /** Implementation specific tests here */
+    // Implementation specific tests here
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testDateReturnsDateTimeObject()
     {
         $dateHeader = new Date();
@@ -151,6 +150,7 @@ class DateTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()

--- a/test/Header/DateTest.php
+++ b/test/Header/DateTest.php
@@ -35,7 +35,7 @@ class DateTest extends TestCase
         $this->assertInstanceOf(HeaderInterface::class, $dateHeader);
         $this->assertInstanceOf(Date::class, $dateHeader);
 
-        $date     = new DateTime(null, new DateTimeZone('GMT'));
+        $date     = new DateTime('now', new DateTimeZone('GMT'));
         $interval = $dateHeader->date()->diff($date, 1);
 
         if (PHP_VERSION_ID >= 70200) {
@@ -54,7 +54,7 @@ class DateTest extends TestCase
         $this->assertInstanceOf(HeaderInterface::class, $dateHeader);
         $this->assertInstanceOf(Date::class, $dateHeader);
 
-        $date     = new DateTime(null, new DateTimeZone('GMT'));
+        $date     = new DateTime('now', new DateTimeZone('GMT'));
         $interval = $dateHeader->date()->diff($date, 1);
 
         if (PHP_VERSION_ID >= 70200) {

--- a/test/Header/EtagTest.php
+++ b/test/Header/EtagTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Etag;
@@ -50,6 +44,7 @@ class EtagTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class EtagTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ExpectTest.php
+++ b/test/Header/ExpectTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class ExpectTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ExpectTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ExpiresTest.php
+++ b/test/Header/ExpiresTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -44,11 +38,13 @@ class ExpiresTest extends TestCase
 
     /**
      * Implementation specific tests are covered by DateTest
+     *
      * @see LaminasTest\Http\Header\DateTest
      */
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()

--- a/test/Header/FeaturePolicyTest.php
+++ b/test/Header/FeaturePolicyTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -30,8 +24,8 @@ class FeaturePolicyTest extends TestCase
         $this->assertInstanceOf(FeaturePolicy::class, $header);
         $directives = [
             'geolocation' => "'none'",
-            'autoplay' => "'self'",
-            'microphone' => "'self'",
+            'autoplay'    => "'self'",
+            'microphone'  => "'self'",
         ];
         $this->assertEquals($directives, $header->getDirectives());
     }
@@ -95,6 +89,7 @@ class FeaturePolicyTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -105,6 +100,7 @@ class FeaturePolicyTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaDirective()

--- a/test/Header/FromTest.php
+++ b/test/Header/FromTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class FromTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class FromTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/GenericHeaderTest.php
+++ b/test/Header/GenericHeaderTest.php
@@ -1,22 +1,17 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
 use Laminas\Http\Header\GenericHeader;
 use PHPUnit\Framework\TestCase;
 
+use function ord;
+
 class GenericHeaderTest extends TestCase
 {
     /**
      * @dataProvider validFieldNameChars
-     *
      * @param string $name
      */
     public function testValidFieldName($name)
@@ -34,7 +29,6 @@ class GenericHeaderTest extends TestCase
 
     /**
      * @dataProvider invalidFieldNameChars
-     *
      * @param string $name
      */
     public function testInvalidFieldName($name)
@@ -61,6 +55,7 @@ class GenericHeaderTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -71,6 +66,7 @@ class GenericHeaderTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()
@@ -81,6 +77,7 @@ class GenericHeaderTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testProtectsFromCRLFAttackViaSetFieldName()
@@ -93,6 +90,7 @@ class GenericHeaderTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testProtectsFromCRLFAttackViaSetFieldValue()

--- a/test/Header/HeaderValueTest.php
+++ b/test/Header/HeaderValueTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -16,8 +10,10 @@ class HeaderValueTest extends TestCase
 {
     /**
      * Data for filter value
+     *
+     * @psalm-return array<array-key, array{0: string, 1: string}>
      */
-    public function getFilterValues()
+    public function getFilterValues(): array
     {
         return [
             ["This is a\n test", 'This is a test'],
@@ -36,9 +32,7 @@ class HeaderValueTest extends TestCase
 
     /**
      * @group ZF2015-04
-     *
      * @dataProvider getFilterValues
-     *
      * @param string $value
      * @param string $expected
      */
@@ -47,7 +41,8 @@ class HeaderValueTest extends TestCase
         $this->assertEquals($expected, HeaderValue::filter($value));
     }
 
-    public function validateValues()
+    /** @psalm-return array<array-key, array{0: string, 1: string}> */
+    public function validateValues(): array
     {
         return [
             ["This is a\n test", 'assertFalse'],
@@ -66,9 +61,7 @@ class HeaderValueTest extends TestCase
 
     /**
      * @group ZF2015-04
-     *
      * @dataProvider validateValues
-     *
      * @param string $value
      * @param string $assertion
      */
@@ -77,7 +70,8 @@ class HeaderValueTest extends TestCase
         $this->{$assertion}(HeaderValue::isValid($value));
     }
 
-    public function assertValues()
+    /** @psalm-return array<array-key, array{0: string}> */
+    public function assertValues(): array
     {
         return [
             ["This is a\n test"],
@@ -95,9 +89,7 @@ class HeaderValueTest extends TestCase
 
     /**
      * @group ZF2015-04
-     *
      * @dataProvider assertValues
-     *
      * @param string $value
      */
     public function testAssertValidRaisesExceptionForInvalidValue($value)

--- a/test/Header/HostTest.php
+++ b/test/Header/HostTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class HostTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class HostTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/IfMatchTest.php
+++ b/test/Header/IfMatchTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class IfMatchTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class IfMatchTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/IfModifiedSinceTest.php
+++ b/test/Header/IfModifiedSinceTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -44,11 +38,13 @@ class IfModifiedSinceTest extends TestCase
 
     /**
      * Implementation specific tests are covered by DateTest
+     *
      * @see LaminasTest\Http\Header\DateTest
      */
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()

--- a/test/Header/IfNoneMatchTest.php
+++ b/test/Header/IfNoneMatchTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class IfNoneMatchTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class IfNoneMatchTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/IfRangeTest.php
+++ b/test/Header/IfRangeTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class IfRangeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class IfRangeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/IfUnmodifiedSinceTest.php
+++ b/test/Header/IfUnmodifiedSinceTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -44,11 +38,13 @@ class IfUnmodifiedSinceTest extends TestCase
 
     /**
      * Implementation specific tests are covered by DateTest
+     *
      * @see LaminasTest\Http\Header\DateTest
      */
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testCRLFAttack()

--- a/test/Header/KeepAliveTest.php
+++ b/test/Header/KeepAliveTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class KeepAliveTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class KeepAliveTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/LastModifiedTest.php
+++ b/test/Header/LastModifiedTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -44,11 +38,13 @@ class LastModifiedTest extends TestCase
 
     /**
      * Implementation specific tests are covered by DateTest
+     *
      * @see LaminasTest\Http\Header\DateTest
      */
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()

--- a/test/Header/LocationTest.php
+++ b/test/Header/LocationTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -22,7 +16,6 @@ class LocationTest extends TestCase
 {
     /**
      * @dataProvider locationFromStringCreatesValidLocationHeaderProvider
-     *
      * @param string $uri The URL to redirect to
      */
     public function testLocationFromStringCreatesValidLocationHeader($uri)
@@ -32,7 +25,8 @@ class LocationTest extends TestCase
         $this->assertInstanceOf(Location::class, $locationHeader);
     }
 
-    public function locationFromStringCreatesValidLocationHeaderProvider()
+    /** @psalm-return array<array-key, array{0: string}> */
+    public function locationFromStringCreatesValidLocationHeaderProvider(): array
     {
         return [
             ['http://www.example.com'],
@@ -46,7 +40,6 @@ class LocationTest extends TestCase
      * Test that we can set a redirect to different URI-Schemes
      *
      * @dataProvider locationCanSetDifferentSchemeUrisProvider
-     *
      * @param string $uri
      * @param string $expectedClass
      */
@@ -61,13 +54,12 @@ class LocationTest extends TestCase
      * Test that we can set a redirect to different URI-schemes via a class
      *
      * @dataProvider locationCanSetDifferentSchemeUrisProvider
-     *
      * @param string $uri
      * @param string $expectedClass
      */
     public function testLocationCanSetDifferentSchemeUriObjects($uri, $expectedClass)
     {
-        $uri = UriFactory::factory($uri);
+        $uri            = UriFactory::factory($uri);
         $locationHeader = new Location();
         $locationHeader->setUri($uri);
         $this->assertInstanceOf($expectedClass, $locationHeader->uri());
@@ -106,12 +98,13 @@ class LocationTest extends TestCase
         $this->assertEquals('Location: http://www.example.com/path?query', $locationHeader->toString());
     }
 
-    /** Implementation specific tests here */
+    // Implementation specific tests here
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testLocationCanSetAndAccessAbsoluteUri()
     {
         $locationHeader = Location::fromString('Location: http://www.example.com/path');
-        $uri = $locationHeader->uri();
+        $uri            = $locationHeader->uri();
         $this->assertInstanceOf(Http::class, $uri);
         $this->assertTrue($uri->isAbsolute());
         $this->assertEquals('http://www.example.com/path', $locationHeader->getUri());
@@ -120,7 +113,7 @@ class LocationTest extends TestCase
     public function testLocationCanSetAndAccessRelativeUri()
     {
         $locationHeader = Location::fromString('Location: /path/to');
-        $uri = $locationHeader->uri();
+        $uri            = $locationHeader->uri();
         $this->assertInstanceOf(Uri::class, $uri);
         $this->assertFalse($uri->isAbsolute());
         $this->assertEquals('/path/to', $locationHeader->getUri());
@@ -128,6 +121,7 @@ class LocationTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testCRLFAttack()

--- a/test/Header/MaxForwardsTest.php
+++ b/test/Header/MaxForwardsTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class MaxForwardsTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class MaxForwardsTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructorValue()

--- a/test/Header/OriginTest.php
+++ b/test/Header/OriginTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -47,6 +41,7 @@ class OriginTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()

--- a/test/Header/PragmaTest.php
+++ b/test/Header/PragmaTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class PragmaTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class PragmaTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ProxyAuthenticateTest.php
+++ b/test/Header/ProxyAuthenticateTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class ProxyAuthenticateTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ProxyAuthenticateTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ProxyAuthorizationTest.php
+++ b/test/Header/ProxyAuthorizationTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class ProxyAuthorizationTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ProxyAuthorizationTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/RangeTest.php
+++ b/test/Header/RangeTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class RangeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class RangeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructorValue()

--- a/test/Header/RefererTest.php
+++ b/test/Header/RefererTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -44,12 +38,13 @@ class RefererTest extends TestCase
         $this->assertEquals('Referer: http://www.example.com/path?query', $refererHeader->toString());
     }
 
-    /** Implementation specific tests here */
+    // Implementation specific tests here
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testRefererCanSetAndAccessAbsoluteUri()
     {
         $refererHeader = Referer::fromString('Referer: http://www.example.com/path');
-        $uri = $refererHeader->uri();
+        $uri           = $refererHeader->uri();
         $this->assertInstanceOf(Http::class, $uri);
         $this->assertTrue($uri->isAbsolute());
         $this->assertEquals('http://www.example.com/path', $refererHeader->getUri());
@@ -58,7 +53,7 @@ class RefererTest extends TestCase
     public function testRefererCanSetAndAccessRelativeUri()
     {
         $refererHeader = Referer::fromString('Referer: /path/to');
-        $uri = $refererHeader->uri();
+        $uri           = $refererHeader->uri();
         $this->assertInstanceOf(Uri::class, $uri);
         $this->assertFalse($uri->isAbsolute());
         $this->assertEquals('/path/to', $refererHeader->getUri());
@@ -73,6 +68,7 @@ class RefererTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testCRLFAttack()

--- a/test/Header/RefreshTest.php
+++ b/test/Header/RefreshTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class RefreshTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class RefreshTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructorValue()

--- a/test/Header/RetryAfterTest.php
+++ b/test/Header/RetryAfterTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -57,6 +51,7 @@ class RetryAfterTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()

--- a/test/Header/ServerTest.php
+++ b/test/Header/ServerTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class ServerTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ServerTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/TETest.php
+++ b/test/Header/TETest.php
@@ -1,10 +1,4 @@
-<?php
-
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
+<?php // phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCaps
 
 namespace LaminasTest\Http\Header;
 
@@ -50,6 +44,7 @@ class TETest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class TETest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/TrailerTest.php
+++ b/test/Header/TrailerTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class TrailerTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class TrailerTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/TransferEncodingTest.php
+++ b/test/Header/TransferEncodingTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class TransferEncodingTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class TransferEncodingTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/UpgradeTest.php
+++ b/test/Header/UpgradeTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class UpgradeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class UpgradeTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/UserAgentTest.php
+++ b/test/Header/UserAgentTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class UserAgentTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class UserAgentTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/VaryTest.php
+++ b/test/Header/VaryTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class VaryTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class VaryTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/ViaTest.php
+++ b/test/Header/ViaTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class ViaTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class ViaTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/Header/WWWAuthenticateTest.php
+++ b/test/Header/WWWAuthenticateTest.php
@@ -1,10 +1,4 @@
-<?php
-
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
+<?php // phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCaps
 
 namespace LaminasTest\Http\Header;
 
@@ -50,21 +44,23 @@ class WWWAuthenticateTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
     {
         $this->expectException(InvalidArgumentException::class);
-        $header = WWWAuthenticate::fromString("WWW-Authenticate: xxx\r\n\r\nevilContent");
+        WWWAuthenticate::fromString("WWW-Authenticate: xxx\r\n\r\nevilContent");
     }
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()
     {
         $this->expectException(InvalidArgumentException::class);
-        $header = new WWWAuthenticate("xxx\r\n\r\nevilContent");
+        new WWWAuthenticate("xxx\r\n\r\nevilContent");
     }
 }

--- a/test/Header/WarningTest.php
+++ b/test/Header/WarningTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Header;
 
 use Laminas\Http\Header\Exception\InvalidArgumentException;
@@ -50,6 +44,7 @@ class WarningTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaFromString()
@@ -60,6 +55,7 @@ class WarningTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testPreventsCRLFAttackViaConstructor()

--- a/test/HeaderTest.php
+++ b/test/HeaderTest.php
@@ -1,22 +1,20 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http;
 
 use Laminas\Http\Exception\InvalidArgumentException;
 use Laminas\Http\Header;
 use PHPUnit\Framework\TestCase;
 
+use function strtolower;
+use function strtoupper;
+
 class HeaderTest extends TestCase
 {
-    public function header()
+    /** @psalm-return iterable<string, array{0: class-string, 1: string}> */
+    public function header(): iterable
     {
-        // @codingStandardsIgnoreStart
+        // phpcs:disable Generic.Files.LineLength.TooLong
         yield Header\AcceptRanges::class            => [Header\AcceptRanges::class, 'Accept-Ranges'];
         yield Header\AuthenticationInfo::class      => [Header\AuthenticationInfo::class, 'Authentication-Info'];
         yield Header\Authorization::class           => [Header\Authorization::class, 'Authorization'];
@@ -53,12 +51,12 @@ class HeaderTest extends TestCase
         yield Header\Via::class                     => [Header\Via::class, 'Via'];
         yield Header\Warning::class                 => [Header\Warning::class, 'Warning'];
         yield Header\WWWAuthenticate::class         => [Header\WWWAuthenticate::class, 'WWW-Authenticate'];
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
     }
 
     /**
+     * phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
      * @dataProvider header
-     *
      * @param string $class
      * @param string $name
      */
@@ -70,8 +68,8 @@ class HeaderTest extends TestCase
     }
 
     /**
+     * phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
      * @dataProvider header
-     *
      * @param string $class
      * @param string $name
      */
@@ -85,8 +83,8 @@ class HeaderTest extends TestCase
     }
 
     /**
+     * phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
      * @dataProvider header
-     *
      * @param string $class
      * @param string $name
      */
@@ -100,8 +98,8 @@ class HeaderTest extends TestCase
     }
 
     /**
+     * phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
      * @dataProvider header
-     *
      * @param string $class
      * @param string $name
      */
@@ -114,8 +112,8 @@ class HeaderTest extends TestCase
     }
 
     /**
+     * phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
      * @dataProvider header
-     *
      * @param string $class
      * @param string $name
      *
@@ -131,8 +129,8 @@ class HeaderTest extends TestCase
     }
 
     /**
+     * phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
      * @dataProvider header
-     *
      * @param string $class
      * @param string $name
      */
@@ -145,8 +143,8 @@ class HeaderTest extends TestCase
     }
 
     /**
+     * phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
      * @dataProvider header
-     *
      * @param string $class
      * @param string $name
      */

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http;
 
 use ArrayIterator;
@@ -20,6 +14,8 @@ use Laminas\Http\Header\HeaderInterface;
 use Laminas\Http\HeaderLoader;
 use Laminas\Http\Headers;
 use PHPUnit\Framework\TestCase;
+
+use function implode;
 
 class HeadersTest extends TestCase
 {
@@ -101,7 +97,7 @@ class HeadersTest extends TestCase
     public function testHeadersFromStringMultiHeaderWillAggregateLazyLoadedHeaders()
     {
         $headers = new Headers();
-        $pcl = $headers->getPluginClassLoader();
+        $pcl     = $headers->getPluginClassLoader();
         $pcl->registerPlugin('foo', GenericMultiHeader::class);
         $headers->addHeaderLine('foo: bar1,bar2,bar3');
         $headers->forceLoading();
@@ -135,7 +131,7 @@ class HeadersTest extends TestCase
     public function testHeadersAggregatesHeaderObjects()
     {
         $fakeHeader = new Header\GenericHeader('Fake', 'bar');
-        $headers = new Headers();
+        $headers    = new Headers();
         $headers->addHeader($fakeHeader);
         $this->assertEquals(1, $headers->count());
         $this->assertSame($fakeHeader, $headers->get('Fake'));
@@ -276,7 +272,7 @@ class HeadersTest extends TestCase
         $cookie2 = new Header\SetCookie('bar', 'baz');
         $headers->addHeader($cookie1);
         $headers->addHeader($cookie2);
-        $array   = $headers->toArray();
+        $array    = $headers->toArray();
         $expected = [
             'Set-Cookie' => [
                 $cookie1->getFieldValue(),
@@ -293,7 +289,7 @@ class HeadersTest extends TestCase
         $cookie2 = new Header\SetCookie('bar', 'baz');
         $headers->addHeader($cookie1);
         $headers->addHeader($cookie2);
-        $string  = $headers->toString();
+        $string   = $headers->toString();
         $expected = [
             'Set-Cookie: ' . $cookie1->getFieldValue(),
             'Set-Cookie: ' . $cookie2->getFieldValue(),
@@ -310,6 +306,7 @@ class HeadersTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testCRLFAttack()

--- a/test/PhpEnvironment/RemoteAddressTest.php
+++ b/test/PhpEnvironment/RemoteAddressTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\PhpEnvironment;
 
 use Laminas\Http\PhpEnvironment\RemoteAddress as RemoteAddr;
@@ -20,9 +14,7 @@ class RemoteAddressTest extends TestCase
      */
     protected $originalEnvironment;
 
-    /**
-     * @var RemoteAddr
-     */
+    /** @var RemoteAddr */
     protected $remoteAddress;
 
     /**
@@ -96,7 +88,7 @@ class RemoteAddressTest extends TestCase
             '192.168.0.10',
             '10.0.0.1',
         ]);
-        $_SERVER['REMOTE_ADDR'] = '192.168.0.10';
+        $_SERVER['REMOTE_ADDR']          = '192.168.0.10';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '8.8.8.8, 10.0.0.1';
         $this->assertEquals('8.8.8.8', $this->remoteAddress->getIpAddress());
     }
@@ -108,7 +100,7 @@ class RemoteAddressTest extends TestCase
             '10.0.0.1',
         ]);
         // the REMOTE_ADDR is not in the trusted IPs, possible attack here
-        $_SERVER['REMOTE_ADDR'] = '1.1.1.1';
+        $_SERVER['REMOTE_ADDR']          = '1.1.1.1';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '8.8.8.8, 10.0.0.1';
         $this->assertEquals('1.1.1.1', $this->remoteAddress->getIpAddress());
     }

--- a/test/PhpEnvironment/ResponseTest.php
+++ b/test/PhpEnvironment/ResponseTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\PhpEnvironment;
 
 use Laminas\Http\Exception\InvalidArgumentException;
@@ -61,7 +55,7 @@ class ResponseTest extends TestCase
     {
         // HTTP/1.0
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.0';
-        $response = new Response();
+        $response                   = new Response();
         $this->assertSame(Response::VERSION_10, $response->getVersion());
     }
 
@@ -69,7 +63,7 @@ class ResponseTest extends TestCase
     {
         // HTTP/1.1
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
-        $response = new Response();
+        $response                   = new Response();
         $this->assertSame(Response::VERSION_11, $response->getVersion());
     }
 
@@ -77,7 +71,7 @@ class ResponseTest extends TestCase
     {
         // unknown protocol or version -> fallback to HTTP/1.0
         $_SERVER['SERVER_PROTOCOL'] = 'laminas/2.0';
-        $response = new Response();
+        $response                   = new Response();
         $this->assertSame(Response::VERSION_10, $response->getVersion());
     }
 

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http;
 
 use Laminas\Http\Exception\InvalidArgumentException;
@@ -19,11 +13,14 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
 
+use function strtolower;
+use function substr;
+
 class RequestTest extends TestCase
 {
     public function testRequestFromStringFactoryCreatesValidRequest()
     {
-        $string = "GET /foo?myparam=myvalue HTTP/1.1\r\n\r\nSome Content";
+        $string  = "GET /foo?myparam=myvalue HTTP/1.1\r\n\r\nSome Content";
         $request = Request::fromString($string);
 
         $this->assertEquals(Request::METHOD_GET, $request->getMethod());
@@ -44,7 +41,7 @@ class RequestTest extends TestCase
     public function testRequestAllowsSettingOfParameterContainer()
     {
         $request = new Request();
-        $p = new Parameters();
+        $p       = new Parameters();
         $request->setQuery($p);
         $request->setPost($p);
         $request->setFiles($p);
@@ -61,7 +58,7 @@ class RequestTest extends TestCase
     public function testRetrievingASingleValueForParameters()
     {
         $request = new Request();
-        $p = new Parameters([
+        $p       = new Parameters([
             'foo' => 'bar',
         ]);
         $request->setQuery($p);
@@ -73,7 +70,7 @@ class RequestTest extends TestCase
         $this->assertSame('bar', $request->getFiles('foo'));
 
         $headers = new Headers();
-        $h = new GenericHeader('foo', 'bar');
+        $h       = new GenericHeader('foo', 'bar');
         $headers->addHeader($h);
 
         $request->setHeaders($headers);
@@ -85,7 +82,7 @@ class RequestTest extends TestCase
     public function testParameterRetrievalDefaultValue()
     {
         $request = new Request();
-        $p = new Parameters([
+        $p       = new Parameters([
             'foo' => 'bar',
         ]);
         $request->setQuery($p);
@@ -139,7 +136,6 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider uriDataProvider
-     *
      * @param string $uri
      */
     public function testRequestCanSetAndRetrieveUri($uri)
@@ -152,7 +148,8 @@ class RequestTest extends TestCase
         $this->assertEquals($uri, $request->getUriString());
     }
 
-    public function uriDataProvider()
+    /** @psalm-return array<array-key, array{0: string}> */
+    public function uriDataProvider(): array
     {
         return [
             ['/foo'],
@@ -189,7 +186,6 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider getMethods
-     *
      * @param string $methodName
      */
     public function testRequestMethodCheckWorksForAllMethods($methodName)
@@ -245,7 +241,7 @@ class RequestTest extends TestCase
     public function testRequestsWithoutHttpVersionAreOK()
     {
         $requestString = 'GET http://www.domain.com/index.php';
-        $request = Request::fromString($requestString);
+        $request       = Request::fromString($requestString);
         $this->assertEquals($request::METHOD_GET, $request->getMethod());
     }
 
@@ -257,13 +253,13 @@ class RequestTest extends TestCase
     public function getMethods($providerContext, $trueMethod = null)
     {
         $refClass = new ReflectionClass(Request::class);
-        $return = [];
+        $return   = [];
         foreach ($refClass->getConstants() as $cName => $cValue) {
-            if (substr($cName, 0, 6) == 'METHOD') {
+            if (substr($cName, 0, 6) === 'METHOD') {
                 if ($providerContext) {
                     $return[] = [$cValue];
                 } else {
-                    $return[strtolower($cValue)] = $trueMethod == $cValue;
+                    $return[strtolower($cValue)] = $trueMethod === $cValue;
                 }
             }
         }
@@ -326,6 +322,7 @@ class RequestTest extends TestCase
 
     /**
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     *
      * @group ZF2015-04
      */
     public function testCRLFAttack()

--- a/test/Response/ResponseStreamTest.php
+++ b/test/Response/ResponseStreamTest.php
@@ -1,15 +1,22 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\Response;
 
 use Laminas\Http\Response\Stream;
 use PHPUnit\Framework\TestCase;
+
+use function fgets;
+use function file_exists;
+use function fopen;
+use function fread;
+use function fwrite;
+use function md5;
+use function rewind;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+use const DIRECTORY_SEPARATOR;
 
 class ResponseStreamTest extends TestCase
 {
@@ -42,7 +49,6 @@ class ResponseStreamTest extends TestCase
 
     /**
      * @group 6027
-     *
      * @covers \Laminas\Http\Response\Stream::fromStream
      */
     public function testResponseFactoryFromEmptyStringCreatesValidResponse()
@@ -63,7 +69,7 @@ class ResponseStreamTest extends TestCase
         $headers = '';
         while (false !== ($newLine = fgets($stream))) {
             $headers .= $newLine;
-            if ($headers == "\n" || $headers == "\r\n") {
+            if ($headers === "\n" || $headers === "\r\n") {
                 break;
             }
         }
@@ -99,7 +105,8 @@ class ResponseStreamTest extends TestCase
     public function testDestructionDoesNothingIfStreamIsNotAResourceAndStreamNameIsNotAString(): void
     {
         $this->tempFile = tempnam(sys_get_temp_dir(), 'lhrs');
-        $streamObject = new class($this->tempFile) {
+        $streamObject   = new class ($this->tempFile) {
+            /** @var string */
             private $tempFile;
 
             public function __construct(string $tempFile)
@@ -107,7 +114,7 @@ class ResponseStreamTest extends TestCase
                 $this->tempFile = $tempFile;
             }
 
-            public function __toString()
+            public function __toString(): string
             {
                 return $this->tempFile;
             }
@@ -136,14 +143,14 @@ class ResponseStreamTest extends TestCase
         $data = '';
         while (false !== ($newLine = fgets($stream))) {
             $data .= $newLine;
-            if ($newLine == "\n" || $newLine == "\r\n") {
+            if ($newLine === "\n" || $newLine === "\r\n") {
                 break;
             }
         }
 
         $data .= fread($stream, 100); // Should accept also part of body as text
 
-        $return = [];
+        $return           = [];
         $return['stream'] = $stream;
         $return['data']   = $data;
 

--- a/test/TestAsset/ExtendedClient.php
+++ b/test/TestAsset/ExtendedClient.php
@@ -1,16 +1,10 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-http for the canonical source repository
- * @copyright https://github.com/laminas/laminas-http/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-http/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Http\TestAsset;
 
 use Laminas\Http\Client;
 
 class ExtendedClient extends Client
 {
-    const AUTH_CUSTOM = 'custom';
+    public const AUTH_CUSTOM = 'custom';
 }


### PR DESCRIPTION
This patch provides support for PHP 8.1, via the following changes:

- Adds `~8.1.0` to the list of allowed PHP versions
- Changes how the package replaces zend-http
  - Renames the "replace" section in the packager to "conflict"
    - Changes the zend-http constraint to "*"
  - Removes the dependency on laminas-zendframework-bridge
- Removes dev requirement on laminas-config; testing can be done with vanilla `Traversable` classes.
- Bumps PHPUnit to 9.5 series
- Bumps laminas-stdlib, laminas-uri, laminas-loader, and laminas-validator dependencies to versions known to work with PHP 8.1
- Bumps laminas-coding-standard to 2.2 series, and applies the updated rulest
- Adds the `ReturnTypeWillChange` attribute to `Headers` methods implementing internal interfaces
- Provides a variety of small functionality fixes to work with PHP 8.1, primarily by using null coalesce to transform null return values to the appropriate type for `str*`, `preg_*`, and other internal methods.
