### PR TITLE
`Headers#toArray` does not properly return all header values

### DIFF
--- a/src/Headers.php
+++ b/src/Headers.php
@@ -439,13 +439,15 @@ class Headers implements Countable, Iterator
      */
     public function toArray()
     {
+        if ($this->headers === []) {
+            return [];
+        }
+
+        $this->forceLoading();
+
         $headers = [];
         /** @var Header\HeaderInterface $header */
-        foreach ($this->headers as $index => $header) {
-            if (is_array($header)) {
-                $header = $this->lazyLoadHeader($index);
-            }
-
+        foreach ($this->headers as $header) {
             if ($header instanceof Header\MultipleHeaderInterface) {
                 $name = $header->getFieldName();
                 if (! isset($headers[$name])) {
@@ -456,6 +458,7 @@ class Headers implements Countable, Iterator
                 $headers[$header->getFieldName()] = $header->getFieldValue();
             }
         }
+
         return $headers;
     }
 

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -16,6 +16,7 @@ use Laminas\Http\Headers;
 use PHPUnit\Framework\TestCase;
 
 use function implode;
+use function sprintf;
 
 class HeadersTest extends TestCase
 {
@@ -438,5 +439,19 @@ class HeadersTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid header value detected');
         $headers->get('Location');
+    }
+
+    public function testToArrayCanHandleIteratorExtensionForMultipleHeaderValue()
+    {
+        $headerValue = 'cookie1=value1; Expires=Sun, 02-Jan-2022 08:54:16 GMT; Domain=.example.org; Path=/;'
+        . ' Secure; SameSite=Lax, cookie2=value2; Expires=Sun, 02-Jan-2022 08:54:16 GMT; Domain=.example.org; Path=/;'
+        . ' Secure; SameSite=Lax, cookie3=value3; Expires=Sun, 02-Jan-2022 08:54:16 GMT; Domain=.example.org; Path=/;'
+        . ' Secure; SameSite=Lax';
+        $headers     = Headers::fromString(sprintf('Set-Cookie: %s', $headerValue));
+
+        $headersArray = $headers->toArray();
+        self::assertCount(1, $headersArray);
+        self::assertArrayHasKey('Set-Cookie', $headersArray);
+        self::assertEquals($headerValue, implode(', ', $headersArray['Set-Cookie']));
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

When working on a project in combination with the `laminas/laminas-psr7bridge` and `laminas/laminas-diactoros`, we ran into a bug where the `Headers#toArray` method iterated over its (not initialized) headers and thus extended the array which is currently iterated within `Headers#lazyLoadHeader`:
https://github.com/laminas/laminas-http/blob/e1f3420ab35e21ea135913d213b8d570e5e7b513/src/Headers.php#L507

Not sure if this ever worked properly tho. 
*Maybe* another problem is that `Set-Cookie` is merged into a single value in https://github.com/laminas/laminas-psr7bridge/blob/a560f42d66fc11b0b05e7d2103e69e434365e7c1/src/Psr7Response.php#L80 as well but as of now, extending an iterator while its being iterated simply won't work for an array and thus, I've rewritten the way how `Headers#toArray` works by enforcing the lazy conversion before iterating over the headers.
