### PR TITLE
Regression: non-float HTTP version detection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "laminas/laminas-validator": "^2.15"
     },
     "require-dev": {
+        "ext-curl": "*",
         "laminas/laminas-coding-standard": "~2.2.1",
         "phpunit/phpunit": "^9.5.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3bfcee73d78e113600374665bbe4e8a0",
+    "content-hash": "0bbed9b69347e59d9cdceda2f85455d5",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -2866,6 +2866,8 @@
     "platform": {
         "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
-    "platform-dev": [],
+    "platform-dev": {
+        "ext-curl": "*"
+    },
     "plugin-api-version": "2.1.0"
 }

--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -23,8 +23,10 @@ use function gettype;
 use function in_array;
 use function intval;
 use function is_array;
+use function is_float;
 use function is_numeric;
 use function is_resource;
+use function number_format;
 use function preg_match;
 use function preg_replace;
 use function preg_split;
@@ -334,7 +336,7 @@ class Curl implements HttpAdapter, StreamInterface
      *
      * @param  string        $method
      * @param Uri $uri
-     * @param  float         $httpVersion
+     * @param  float|string  $httpVersion
      * @param  array         $headers
      * @param  string        $body
      * @return string        $request
@@ -344,8 +346,12 @@ class Curl implements HttpAdapter, StreamInterface
      * @throws AdapterException\InvalidArgumentException If $method is currently not supported.
      * @throws AdapterException\TimeoutException If connection timed out.
      */
-    public function write($method, $uri, $httpVersion = 1.1, $headers = [], $body = '')
+    public function write($method, $uri, $httpVersion = '1.1', $headers = [], $body = '')
     {
+        if (is_float($httpVersion)) {
+            $httpVersion = number_format($httpVersion, 1, '.', '');
+        }
+
         // Make sure we're properly connected
         if (! $this->curl) {
             throw new AdapterException\RuntimeException('Trying to write but we are not connected');
@@ -442,7 +448,7 @@ class Curl implements HttpAdapter, StreamInterface
         }
 
         // get http version to use
-        $curlHttp = $httpVersion === 1.1 ? CURL_HTTP_VERSION_1_1 : CURL_HTTP_VERSION_1_0;
+        $curlHttp = $httpVersion === '1.1' ? CURL_HTTP_VERSION_1_1 : CURL_HTTP_VERSION_1_0;
 
         // mark as HTTP request and set HTTP method
         curl_setopt($this->curl, CURLOPT_HTTP_VERSION, $curlHttp);

--- a/test/Client/Adapter/CurlTest.php
+++ b/test/Client/Adapter/CurlTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Http\Client\Adapter;
+
+use Laminas\Http\Client\Adapter\Curl;
+use Laminas\Uri\Uri;
+use PHPUnit\Framework\TestCase;
+
+use function curl_getinfo;
+
+use const CURL_HTTP_VERSION_1_0;
+use const CURL_HTTP_VERSION_1_1;
+use const CURLINFO_HTTP_VERSION;
+
+final class CurlTest extends TestCase
+{
+    /** @var Curl */
+    private $adapter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->adapter = new Curl();
+    }
+
+    /**
+     * @return iterable<non-empty-string,array{0:CURL_HTTP_VERSION_*,1:float}>
+     */
+    public function floatHttpVersions(): iterable
+    {
+        yield 'HTTP 1.0' => [CURL_HTTP_VERSION_1_0, 1.0];
+        yield 'HTTP 1.1' => [CURL_HTTP_VERSION_1_1, 1.1];
+    }
+
+    /**
+     * @return iterable<non-empty-string,array{0:CURL_HTTP_VERSION_*,1:float}>
+     */
+    public function httpVersions(): iterable
+    {
+        yield 'HTTP 1.0' => [CURL_HTTP_VERSION_1_0, '1.0'];
+        yield 'HTTP 1.1' => [CURL_HTTP_VERSION_1_1, '1.1'];
+    }
+
+    /**
+     * NOTE: This test is only needed for BC compatibility. The {@see \Laminas\Http\Client\Adapter\AdapterInterface}
+     *       has a default for "string" but "float" was used in {@see Curl::write()} due to the lack of strict types.
+     *
+     * @dataProvider floatHttpVersions
+     */
+    public function testWriteCanHandleFloatHttpVersion(int $expectedCurlOption, float $version): void
+    {
+        $this->adapter->connect('example.org');
+        $this->adapter->write('GET', new Uri('http://example.org:80/'), $version);
+        $handle = $this->adapter->getHandle();
+        self::assertNotNull($handle);
+        self::assertEquals($expectedCurlOption, curl_getinfo($handle, CURLINFO_HTTP_VERSION));
+    }
+
+    /**
+     * @dataProvider httpVersions
+     */
+    public function testWriteCanHandleStringHttpVersion(int $expectedCurlOption, string $version): void
+    {
+        $this->adapter->connect('example.org');
+        $this->adapter->write('GET', new Uri('http://example.org:80/'), $version);
+        $handle = $this->adapter->getHandle();
+        self::assertNotNull($handle);
+        self::assertEquals($expectedCurlOption, curl_getinfo($handle, CURLINFO_HTTP_VERSION));
+    }
+}

--- a/test/Client/CurlTest.php
+++ b/test/Client/CurlTest.php
@@ -16,7 +16,6 @@ use ValueError;
 use function base64_encode;
 use function curl_getinfo;
 use function explode;
-use function extension_loaded;
 use function file_get_contents;
 use function filesize;
 use function fopen;
@@ -71,9 +70,6 @@ class CurlTest extends CommonHttpTests
 
     protected function setUp(): void
     {
-        if (! extension_loaded('curl')) {
-            $this->markTestSkipped('cURL is not installed, marking all Http Client Curl Adapter tests skipped.');
-        }
         parent::setUp();
     }
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | yes (fixed now)

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With v2.15.0, we've also added some stricter comparisons of variables. The HTTP `AdapterInterface` states it consumes string values but somehow, the `Curl` adapter implemented the default as float.
Due to the lack of strict comparison and strict types, that worked well before we added `===`.

This patch allows both `string` and `float` values.
