### PR TITLE
Remove exception for PHP 8.1 for installing php-fpm

### DIFF
--- a/.laminas-ci/pre-run.sh
+++ b/.laminas-ci/pre-run.sh
@@ -21,13 +21,7 @@ cp .laminas-ci/phpunit.xml phpunit.xml
 apt update -qq
 # Hack because apache2 package attempts to write to 000-default.conf twice
 apt-get install -o Dpkg::Options::="--force-confnew" -y apache2
-if [[ "${PHP_VERSION}" == "8.1" ]];then
-    # This might not be necessary
-    # switch_sapi -v 8.1 -s fpm:apache
-    echo "Skipping FPM installation on PHP 8.1"
-else
-    apt install -y "php${PHP_VERSION}-fpm"
-fi
+apt install -y "php${PHP_VERSION}-fpm"
 
 # Enable required modules
 a2enmod rewrite actions proxy_fcgi setenvif alias


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

We've recently switched over to SURY PHP 8.1 and thus, we have to remove the installation exception for php-fpm here as it is not installed by default anymore.
