### PR TITLE
Allows `require-trusted-types-for` CSP directive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
         "forum": "https://discourse.laminas.dev"
     },
     "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
         "sort-packages": true
     },
     "require": {

--- a/src/Header/ContentSecurityPolicy.php
+++ b/src/Header/ContentSecurityPolicy.php
@@ -62,6 +62,7 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
         // Other directives
         'block-all-mixed-content',
         'require-sri-for',
+        'require-trusted-types-for',
         'trusted-types',
         'upgrade-insecure-requests',
     ];

--- a/test/Header/ContentSecurityPolicyTest.php
+++ b/test/Header/ContentSecurityPolicyTest.php
@@ -217,6 +217,7 @@ class ContentSecurityPolicyTest extends TestCase
             // Other directives
             ['block-all-mixed-content', [], 'Content-Security-Policy: block-all-mixed-content;'],
             ['require-sri-for', ['script', 'style'], 'Content-Security-Policy: require-sri-for script style;'],
+            ['require-trusted-types-for', ['script'], 'Content-Security-Policy: require-trusted-types-for script;'],
             ['trusted-types', ['*'], 'Content-Security-Policy: trusted-types *;'],
             ['upgrade-insecure-requests', [], 'Content-Security-Policy: upgrade-insecure-requests;'],
         ];


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | no

### Description

When headers contain `require-trusted-types-for` CSP directive, `Headers::toArray` ends with a PHP Fatal Error.

To reproduce:

```
use Laminas\Http\Client;
$client = new Client('http://news.google.com/news?ned=us&topic=t&output=atom');
$client->send()->getHeaders()->toArray();
```

Current result:

```
PHP Fatal error: Uncaught Error: [] operator not supported for strings in vendor/laminas/laminas-http/src/Headers.php:456
```