### PR TITLE
Remove dynamic properties to remove PHP 8.2 deprecation warnings

### DIFF
--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -68,6 +68,13 @@ class SetCookie implements MultipleHeaderInterface
     ];
 
     /**
+     * @deprecated This property is deprecated, and will be removed
+     *
+     * @var string
+     */
+    public $type;
+
+    /**
      * Cookie name
      *
      * @var string|null
@@ -264,6 +271,8 @@ class SetCookie implements MultipleHeaderInterface
         $version = null,
         $sameSite = null
     ) {
+        $this->type = 'Cookie';
+
         $this->setName($name)
              ->setValue($value)
              ->setVersion($version)

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -264,8 +264,6 @@ class SetCookie implements MultipleHeaderInterface
         $version = null,
         $sameSite = null
     ) {
-        $this->type = 'Cookie';
-
         $this->setName($name)
              ->setValue($value)
              ->setVersion($version)

--- a/src/PhpEnvironment/Response.php
+++ b/src/PhpEnvironment/Response.php
@@ -16,6 +16,13 @@ use function headers_sent;
 class Response extends HttpResponse
 {
     /**
+     * @deprecated This property is deprecated, and will be removed
+     *
+     * @var bool
+     */
+    public $headersSent;
+
+    /**
      * The current used version
      * (The value will be detected on getVersion)
      *
@@ -110,6 +117,7 @@ class Response extends HttpResponse
             header($header->toString());
         }
 
+        $this->headersSent = true;
         return $this;
     }
 

--- a/src/PhpEnvironment/Response.php
+++ b/src/PhpEnvironment/Response.php
@@ -110,7 +110,6 @@ class Response extends HttpResponse
             header($header->toString());
         }
 
-        $this->headersSent = true;
         return $this;
     }
 


### PR DESCRIPTION
Signed-off-by: Ádám Bálint <adam.balint@srg.hu>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no


In PHP 8.2 dynamic properties will be deprecated. I found two dynamic properties, and as I see these properties aren't used, only set. I know that because of the dynamic declaration these properties will be public, so there is the possibility that someone uses these properties. This is why it can be BC break. 
Or should I create these public properties in these classes?
