### PR TITLE
Fix Content-Length for POST when data empty

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1255,6 +1255,10 @@ class Client implements DispatchableInterface
             } else {
                 $headers['Content-Length'] = strlen($body);
             }
+        } else {
+            if ($this->getMethod() === 'POST' || $this->getMethod() === 'PUT') {
+                $headers['Content-Length'] = 0;
+            }
         }
 
         // Merge the headers of the request (if any)

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -505,6 +505,29 @@ class ClientTest extends TestCase
         $this->assertSame(Client::ENC_URLENCODED, $client->getEncType());
     }
 
+    public function testClientEmptyPostPut()
+    {
+        $client                   = new Client();
+        $prepareHeadersReflection = new ReflectionMethod($client, 'prepareHeaders');
+        $prepareHeadersReflection->setAccessible(true);
+        $request = new Request();
+        $request->setMethod(Request::METHOD_POST);
+        $client->setRequest($request);
+        $this->assertSame($client->getRequest(), $request);
+        $headers = $prepareHeadersReflection->invoke($client, '', new Http('http://localhost:5984'));
+        $this->assertIsArray($headers);
+        $this->assertArrayHasKey('Content-Length', $headers);
+        $this->assertSame($headers['Content-Length'], 0);
+        $request = new Request();
+        $request->setMethod(Request::METHOD_PUT);
+        $client->setRequest($request);
+        $this->assertSame($client->getRequest(), $request);
+        $headers = $prepareHeadersReflection->invoke($client, '', new Http('http://localhost:5984'));
+        $this->assertIsArray($headers);
+        $this->assertArrayHasKey('Content-Length', $headers);
+        $this->assertSame($headers['Content-Length'], 0);
+    }
+
     /**
      * @group 7332
      */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

The  [RFC7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2) says : 

> For example, a Content-Length header
   field is normally sent in a POST request even when the value is 0
   (indicating an empty payload body).  
   
   Some load balancers reject empty POST without a Content-Lenght set to 0 with an HTTP 411 error. For instance Google Global Load Balancers does.
