### PR TITLE
Refactor navigation and headings for clarity

### DIFF
--- a/docs/book/client/adapters.md
+++ b/docs/book/client/adapters.md
@@ -1,4 +1,4 @@
-# HTTP Client Connection Adapters
+# Connection Adapters
 
 `Laminas\Http\Client` is based on a connection adapter design. The connection adapter is the object in
 charge of performing the actual connection to the server, as well as writing requests and reading

--- a/docs/book/client/advanced.md
+++ b/docs/book/client/advanced.md
@@ -1,4 +1,4 @@
-# HTTP Client Advanced Usage
+# Advanced Usage
 
 ## HTTP redirections
 

--- a/docs/book/client/intro.md
+++ b/docs/book/client/intro.md
@@ -1,4 +1,4 @@
-# HTTP Client
+# Introduction
 
 `Laminas\Http\Client` provides an interface for performing Hyper-Text Transfer
 Protocol (HTTP) requests. `Laminas\Http\Client` supports all basic features

--- a/docs/book/client/static.md
+++ b/docs/book/client/static.md
@@ -1,4 +1,4 @@
-# HTTP Client - Static Usage
+# Static Usage
 
 laminas-http provides another client implementation, `Laminas\Http\ClientStatic`, a
 static HTTP client which exposes a simplified API for quickly performing one-off `GET`

--- a/docs/book/request.md
+++ b/docs/book/request.md
@@ -1,4 +1,4 @@
-# The Request Class
+# Request
 
 `Laminas\Http\Request` is responsible for providing a fluent API that allows a
 developer to interact with all the various parts of an HTTP request.

--- a/docs/book/response.md
+++ b/docs/book/response.md
@@ -1,4 +1,4 @@
-# The Response Class
+# Response
 
 `Laminas\Http\Response` is responsible for providing a fluent API that allows a
 developer to interact with all the various parts of an HTTP response.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,16 +3,15 @@ site_dir: docs/html
 nav:
     - Home: index.md
     - Introduction: intro.md
-    - Reference:
-        - Request: request.md
-        - Response: response.md
-        - Headers: headers.md
-        - Client:
-            - Intro: client/intro.md
-            - Adapters: client/adapters.md
-            - "Static Client": client/static.md
-            - "Cookie Persistence": client/cookies.md
-            - Advanced: client/advanced.md
+    - Request: request.md
+    - Response: response.md
+    - Headers: headers.md
+    - "HTTP Client":
+        - Introduction: client/intro.md
+        - "Connection Adapters": client/adapters.md
+        - "Static Usage": client/static.md
+        - "Client Cookies": client/cookies.md
+        - "Advanced Usage": client/advanced.md
 site_name: laminas-http
 site_description: HTTP message and header abstractions, and HTTP client implementation.  (Not a PSR-7 implementation; see <a href="//docs.laminas.dev/laminas-diactoros">Diactoros</a> for PSR-7 support.
 repo_url: 'https://github.com/laminas/laminas-http'


### PR DESCRIPTION
Simplified the navigation structure in mkdocs.yml and revised document headings for better consistency and readability. The changes improve how the HTTP client sections are organized and presented in the documentation, facilitating easier navigation and comprehension for users.