### PR TITLE
Remove outdated maintenance mode section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,6 @@
 >
 > You trust us enough to use our software. We ask that you trust us to say the truth on this. We need your help. Go out and protest this unnecessary war. Stop the bloodshed. Say "stop the war!"
 
-> This package is considered feature-complete, and is now in **security-only** maintenance mode, following a [decision by the Technical Steering Committee](https://github.com/laminas/technical-steering-committee/blob/2b55453e172a1b8c9c4c212be7cf7e7a58b9352c/meetings/minutes/2020-08-03-TSC-Minutes.md#vote-on-components-to-mark-as-security-only).
-> If you have a security issue, please [follow our security reporting guidelines](https://getlaminas.org/security/).
-> If you wish to take on the role of maintainer, please [nominate yourself](https://github.com/laminas/technical-steering-committee/issues/new?assignees=&labels=Nomination&template=Maintainer_Nomination.md&title=%5BNOMINATION%5D%5BMAINTAINER%5D%3A+%7Bname+of+person+being+nominated%7D)
->
-> You can continue using laminas/laminas-http safely.
-> Its successor will be [PSR-7](https://www.php-fig.org/psr/psr-7/) in a later revision of laminas/laminas-mvc.
-
 [![Build Status](https://travis-ci.com/laminas/laminas-http.svg?branch=master)](https://travis-ci.com/laminas/laminas-http)
 [![Coverage Status](https://coveralls.io/repos/github/laminas/laminas-http/badge.svg?branch=master)](https://coveralls.io/github/laminas/laminas-http?branch=master)
 


### PR DESCRIPTION
The removed section referred to the package's security-only status, along with guidance on security reporting and future maintainership.
