### PR TITLE
Cleanup CSP headers

### DIFF
--- a/src/Header/ContentSecurityPolicy.php
+++ b/src/Header/ContentSecurityPolicy.php
@@ -21,10 +21,8 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
 {
     /**
      * Valid directive names
-     *
-     * @var array
      */
-    protected $validDirectiveNames = [
+    protected array $validDirectiveNames = [
         // As per http://www.w3.org/TR/CSP/#directives
         // Fetch directives
         'child-src',
@@ -36,7 +34,6 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
         'manifest-src',
         'media-src',
         'object-src',
-        'prefetch-src',
         'script-src',
         'script-src-elem',
         'script-src-attr',
@@ -47,7 +44,6 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
 
         // Document directives
         'base-uri',
-        'plugin-types',
         'sandbox',
 
         // Navigation directives
@@ -60,8 +56,6 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
         'report-to',
 
         // Other directives
-        'block-all-mixed-content',
-        'require-sri-for',
         'require-trusted-types-for',
         'trusted-types',
         'upgrade-insecure-requests',

--- a/src/Header/ContentSecurityPolicyReportOnly.php
+++ b/src/Header/ContentSecurityPolicyReportOnly.php
@@ -10,11 +10,49 @@ namespace Laminas\Http\Header;
 class ContentSecurityPolicyReportOnly extends ContentSecurityPolicy
 {
     /**
-     * Get the header name
-     *
-     * @return string
+     * Valid directive names
      */
-    public function getFieldName()
+    protected array $validDirectiveNames = [
+        // As per http://www.w3.org/TR/CSP/#directives
+        // Fetch directives
+        'child-src',
+        'connect-src',
+        'default-src',
+        'font-src',
+        'frame-src',
+        'img-src',
+        'manifest-src',
+        'media-src',
+        'object-src',
+        'script-src',
+        'script-src-elem',
+        'script-src-attr',
+        'style-src',
+        'style-src-elem',
+        'style-src-attr',
+        'worker-src',
+
+        // Document directives
+        'base-uri',
+
+        // Navigation directives
+        'form-action',
+        'frame-ancestors',
+        'navigate-to',
+
+        // Reporting directives
+        'report-uri',
+        'report-to',
+
+        // Other directives
+        'require-trusted-types-for',
+        'trusted-types',
+    ];
+
+    /**
+     * Get the header name
+     */
+    public function getFieldName(): string
     {
         return 'Content-Security-Policy-Report-Only';
     }

--- a/test/Header/ContentSecurityPolicyTest.php
+++ b/test/Header/ContentSecurityPolicyTest.php
@@ -64,10 +64,10 @@ class ContentSecurityPolicyTest extends TestCase
     public function testContentSecurityPolicySetDirective(): void
     {
         $csp = new ContentSecurityPolicy();
-        $csp->setDirective('default-src', ['https://*.google.com', 'http://foo.com'])
+        $csp->setDirective('default-src', ['https://*.google.com', 'https://foo.com'])
             ->setDirective('img-src', ["'self'"])
             ->setDirective('script-src', ['https://*.googleapis.com', 'https://*.bar.com']);
-        $header = 'Content-Security-Policy: default-src https://*.google.com http://foo.com; '
+        $header = 'Content-Security-Policy: default-src https://*.google.com https://foo.com; '
                 . 'img-src \'self\'; script-src https://*.googleapis.com https://*.bar.com;';
         $this->assertEquals($header, $csp->toString());
     }
@@ -100,7 +100,7 @@ class ContentSecurityPolicyTest extends TestCase
     }
 
     /**
-     * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     * @see https://en.wikipedia.org/wiki/HTTP_response_splitting
      */
     #[Group('ZF2015-04')]
     public function testPreventsCRLFAttackViaFromString(): void
@@ -110,7 +110,7 @@ class ContentSecurityPolicyTest extends TestCase
     }
 
     /**
-     * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
+     * @see https://en.wikipedia.org/wiki/HTTP_response_splitting
      */
     #[Group('ZF2015-04')]
     public function testPreventsCRLFAttackViaDirective(): void
@@ -196,29 +196,25 @@ class ContentSecurityPolicyTest extends TestCase
             ['child-src', ["'self'"], "Content-Security-Policy: child-src 'self';"],
             ['manifest-src', ["'self'"], "Content-Security-Policy: manifest-src 'self';"],
             ['worker-src', ["'self'"], "Content-Security-Policy: worker-src 'self';"],
-            ['prefetch-src', ["'self'"], "Content-Security-Policy: prefetch-src 'self';"],
             ['script-src-elem', ["'self'"], "Content-Security-Policy: script-src-elem 'self';"],
             ['script-src-attr', ["'self'"], "Content-Security-Policy: script-src-attr 'self';"],
             ['style-src-elem', ["'self'"], "Content-Security-Policy: style-src-elem 'self';"],
             ['style-src-attr', ["'self'"], "Content-Security-Policy: style-src-attr 'self';"],
             ['base-uri', ["'self'", "'unsafe-inline'"], "Content-Security-Policy: base-uri 'self' 'unsafe-inline';"],
-            ['plugin-types', ['text/csv'], 'Content-Security-Policy: plugin-types text/csv;'],
             [
                 'form-action',
-                ['http://*.example.com', "'self'"],
-                "Content-Security-Policy: form-action http://*.example.com 'self';",
+                ['https://*.example.com', "'self'"],
+                "Content-Security-Policy: form-action https://*.example.com 'self';",
             ],
             [
                 'frame-ancestors',
-                ['http://*.example.com', "'self'"],
-                "Content-Security-Policy: frame-ancestors http://*.example.com 'self';",
+                ['https://*.example.com', "'self'"],
+                "Content-Security-Policy: frame-ancestors https://*.example.com 'self';",
             ],
             ['navigate-to', ['example.com'], 'Content-Security-Policy: navigate-to example.com;'],
             ['sandbox', ['allow-forms'], 'Content-Security-Policy: sandbox allow-forms;'],
 
             // Other directives
-            ['block-all-mixed-content', [], 'Content-Security-Policy: block-all-mixed-content;'],
-            ['require-sri-for', ['script', 'style'], 'Content-Security-Policy: require-sri-for script style;'],
             ['require-trusted-types-for', ['script'], 'Content-Security-Policy: require-trusted-types-for script;'],
             ['trusted-types', ['*'], 'Content-Security-Policy: trusted-types *;'],
             ['upgrade-insecure-requests', [], 'Content-Security-Policy: upgrade-insecure-requests;'],


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no


### Description

This change cleans up the Content Security Policy header implementation and test suite to strictly follow the current CSP Level 3 specification

#### Target branch

Due to the BC break (previously accepted directives are now rejected), target the next major branch: `3.0.x`.

### What changed:
#### ContentSecurityPolicy
Removed deprecated/obsolete directives from the valid directives list:
  - `prefetch-src` - https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/prefetch-src
  - `plugin-types` - https://mdn2.netlify.app/en-us/docs/web/http/headers/content-security-policy/plugin-types/
  - `block-all-mixed-content` - https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/block-all-mixed-content
  - `require-sri-for` - https://udn.realityripple.com/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for

#### ContentSecurityPolicyReportOnly
Defined a dedicated list appropriate for report-only usage, excluding enforcement-only directives (`sandbox` and `upgrade-insecure-requests`)

Why this is necessary:
- The library should reflect the current CSP3 spec and not accept obsolete directives. Accepting them may give a false sense of protection or produce non-spec headers
- Report-only header should only include directives that make sense in report-only mode